### PR TITLE
Feature/extract component script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,10 +39,23 @@ jobs:
       - restore_cache:
           key: node-cache-{{ checksum "package.json" }}
       - run: polymer build
+      - run: mkdir dist
+      - run:
+          name: extract component's code from bundle
+          command: |
+            cat build/prod/src/$COMPONENT_NAME.js | sed -nr '/RISE_COMPONENT/,/<.head>/{
+              /(RISE_COMPONENT|<.head>)/d;
+              s/<script>define/define/;
+              s/;<.script>/;/;
+              p
+            }' > dist/$COMPONENT_NAME.extracted.js
+      - run:
+          name: minify component script once it has been extracted
+          command: ./node_modules/.bin/uglifyjs dist/$COMPONENT_NAME.extracted.js --output dist/$COMPONENT_NAME.js
       - persist_to_workspace:
           root: .
           paths:
-            - build
+            - dist
 
   gcloud-setup:
     docker: &GCSIMAGE
@@ -83,7 +96,7 @@ jobs:
           VERSION=$(cat version-string/version)
           TARGET=$GS_BASE/staging/components/$COMPONENT_NAME/$VERSION/
           echo Deploying version $VERSION to $COMPONENT_NAME
-          gsutil cp build/prod/src/$COMPONENT_NAME.js $TARGET
+          gsutil cp dist/$COMPONENT_NAME.js $TARGET
           gsutil -m setmeta -r -h "Cache-Control:private, max-age=0" $TARGET
           gsutil acl -r ch -u AllUsers:R $TARGET
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,16 +42,7 @@ jobs:
       - run: mkdir dist
       - run:
           name: extract component's code from bundle
-          command: |
-            cat build/prod/html/index.html | sed -nr '/RISE_COMPONENT/,/<.head>/{
-              /(RISE_COMPONENT|<.head>)/d;
-              s/<script>define/define/;
-              s/;<.script>/;/;
-              p
-            }' > extracted.js
-      - run:
-          name: minify component script once it has been extracted
-          command: ./node_modules/.bin/uglifyjs extracted.js --output dist/$COMPONENT_NAME.js
+          command: cat build/prod/html/index.html | perl -pe 's!.*script>(.*shared_bundle.*)</script>.*!$1!' > dist/$COMPONENT_NAME.js
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,15 +43,15 @@ jobs:
       - run:
           name: extract component's code from bundle
           command: |
-            cat build/prod/src/$COMPONENT_NAME.js | sed -nr '/RISE_COMPONENT/,/<.head>/{
+            cat build/prod/html/index.html | sed -nr '/RISE_COMPONENT/,/<.head>/{
               /(RISE_COMPONENT|<.head>)/d;
               s/<script>define/define/;
               s/;<.script>/;/;
               p
-            }' > dist/$COMPONENT_NAME.extracted.js
+            }' > extracted.js
       - run:
           name: minify component script once it has been extracted
-          command: ./node_modules/.bin/uglifyjs dist/$COMPONENT_NAME.extracted.js --output dist/$COMPONENT_NAME.js
+          command: ./node_modules/.bin/uglifyjs extracted.js --output dist/$COMPONENT_NAME.js
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
       - run: mkdir dist
       - run:
           name: extract component's code from bundle
-          command: cat build/prod/html/index.html | perl -pe 's!.*script>(.*shared_bundle.*)</script>.*!$1!' > dist/$COMPONENT_NAME.js
+          command: cat build/prod/html/index.html | perl -pe 's!.*script>(.*$COMPONENT_NAME.*)</script>.*!$1!' > dist/$COMPONENT_NAME.js
       - persist_to_workspace:
           root: .
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
       - run: mkdir dist
       - run:
           name: extract component's code from bundle
-          command: cat build/prod/html/index.html | perl -pe 's!.*script>(.*$COMPONENT_NAME.*)</script>.*!$1!' > dist/$COMPONENT_NAME.js
+          command: cat build/prod/html/index.html | perl -pe 's!.*<script>(.*$COMPONENT_NAME.*)</script>.*!$1!' > dist/$COMPONENT_NAME.js
       - persist_to_workspace:
           root: .
           paths:

--- a/html/index.html
+++ b/html/index.html
@@ -7,13 +7,9 @@
 
     <script src="../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js" async></script>
     <script type="module">
+      // Basic noop script that helps forcing shared bundle file creation.
       import { PolymerElement } from '@polymer/polymer/polymer-element.js';
-
-      // Basic noop element that helps forcing shared bundle file creation.
-      class RiseEnabler extends PolymerElement {
-      }
     </script>
-    <!--#RISE_COMPONENT do not delete this comment, is used by extraction tools-->
     <script src="../src/rise-data-image.js" type="module"></script>
   </head>
   <body>

--- a/html/index.html
+++ b/html/index.html
@@ -5,17 +5,16 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <script src="node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js" async></script>
+    <script src="../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js" async></script>
     <script type="module">
       import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 
       // Basic noop element that helps forcing shared bundle file creation.
       class RiseEnabler extends PolymerElement {
       }
-
-      customElements.define('rise-enabler', RiseEnabler);
     </script>
-    <script src="src/rise-data-image.js" type="module"></script>
+    <!--#RISE_COMPONENT do not delete this comment, is used by extraction tools-->
+    <script src="../src/rise-data-image.js" type="module"></script>
   </head>
   <body>
     This file was created just to enable the build.

--- a/index.html
+++ b/index.html
@@ -6,6 +6,15 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
     <script src="node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js" async></script>
+    <script type="module">
+      import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+
+      // Basic noop element that helps forcing shared bundle file creation.
+      class RiseEnabler extends PolymerElement {
+      }
+
+      customElements.define('rise-enabler', RiseEnabler);
+    </script>
     <script src="src/rise-data-image.js" type="module"></script>
   </head>
   <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1211,12 +1211,6 @@
         "is-fullwidth-code-point": "2.0.0"
       }
     },
-    "source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true
-    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -1370,24 +1364,6 @@
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
       "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
       "dev": true
-    },
-    "uglify-js": {
-      "version": "3.4.9",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
-      "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
-      "dev": true,
-      "requires": {
-        "commander": "2.17.1",
-        "source-map": "0.6.1"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "2.17.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
-          "dev": true
-        }
-      }
     },
     "uri-js": {
       "version": "4.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,43 +22,6 @@
         "chalk": "2.4.1",
         "esutils": "2.0.2",
         "js-tokens": "4.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.3"
-          }
-        },
-        "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.5.0"
-          }
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "3.0.0"
-          }
-        }
       }
     },
     "@polymer/polymer": {
@@ -66,7 +29,7 @@
       "resolved": "https://registry.npmjs.org/@polymer/polymer/-/polymer-3.0.5.tgz",
       "integrity": "sha512-Zbmhtr5vZ3NoHWwFYLKI4ff7yfE6DZopI8vaS7HvmUIuNqsv/EpEDXfNEYjqePQmkMX5LU9OIKV1eX/+9aveow==",
       "requires": {
-        "@webcomponents/shadycss": "1.5.0"
+        "@webcomponents/shadycss": "1.5.2"
       }
     },
     "@polymer/sinonjs": {
@@ -82,14 +45,14 @@
       "dev": true
     },
     "@webcomponents/shadycss": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.5.0.tgz",
-      "integrity": "sha512-jNuC7alo3EfiqZPosCruJuMAaUI9qgiuGxFcFyPWjOpo4BP+vgC7hxpTzQYxbIWUgrqkn9lnfPup2hE9c/h/PQ=="
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.5.2.tgz",
+      "integrity": "sha512-0OyrmVc7S+INtzoqP2ofAo+OdVn2Nj0Qvq4wD9FEGN7nMmLRxaD2mzy6hD6EslzxUSuGH302CDU4KXiY66SEqg=="
     },
     "@webcomponents/webcomponentsjs": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.1.1.tgz",
-      "integrity": "sha512-CgXV1O94jruR0YVijA55bP4SQBRvRKDmByWce47vCZIJ3HPHOph0VtjpO5vYEUyZzfadqfjICBMkZOagTT9XQw=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.1.3.tgz",
+      "integrity": "sha512-0UHJNY88lR3pnEYtBVT7F8cuuxOiITQGWJa0LxoELqkBSB7IabzJFOj5K99PajD3CGAsWpjB0CAeijfe376Y1w=="
     },
     "accessibility-developer-tools": {
       "version": "2.12.0",
@@ -113,9 +76,9 @@
       }
     },
     "ajv": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.3.tgz",
-      "integrity": "sha512-LqZ9wY+fx3UMiiPd741yB2pj3hhil+hQc8taf4o2QGRFpWgZ2V5C8HA165DY9sS3fJwsk7uT7ZlFEyC3Ig3lLg==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.4.tgz",
+      "integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "2.0.1",
@@ -137,16 +100,19 @@
       "dev": true
     },
     "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
       "dev": true
     },
     "ansi-styles": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "dev": true
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "1.9.3"
+      }
     },
     "argparse": {
       "version": "1.0.10",
@@ -229,7 +195,7 @@
     },
     "chai": {
       "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+      "resolved": "http://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
       "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
       "dev": true,
       "requires": {
@@ -239,24 +205,14 @@
       }
     },
     "chalk": {
-      "version": "1.1.3",
-      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+      "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
       "dev": true,
       "requires": {
-        "ansi-styles": "2.2.1",
+        "ansi-styles": "3.2.1",
         "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
-      },
-      "dependencies": {
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
+        "supports-color": "5.5.0"
       }
     },
     "chardet": {
@@ -330,12 +286,12 @@
       }
     },
     "debug": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.5.tgz",
+      "integrity": "sha512-D61LaDQPQkxJ5AUM2mbSJRbPkNs/TmdmOeLAi1hgDkpDfIfetSrjmWhccwtuResSwMbACjx/xXQofvM9CE/aeg==",
       "dev": true,
       "requires": {
-        "ms": "2.0.0"
+        "ms": "2.1.1"
       }
     },
     "deep-eql": {
@@ -398,16 +354,16 @@
       "dev": true
     },
     "eslint": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.5.0.tgz",
-      "integrity": "sha512-m+az4vYehIJgl1Z0gb25KnFXeqQRdNreYsei1jdvkd9bB+UNQD3fsuiC2AWSQ56P+/t++kFSINZXFbfai+krOw==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.6.0.tgz",
+      "integrity": "sha512-/eVYs9VVVboX286mBK7bbKnO1yamUy2UCRjiY6MryhQL2PaaXCExsCQ2aO83OeYRhU2eCU/FMFP+tVMoOrzNrA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.0.0",
-        "ajv": "6.5.3",
+        "ajv": "6.5.4",
         "chalk": "2.4.1",
         "cross-spawn": "6.0.5",
-        "debug": "3.1.0",
+        "debug": "3.2.5",
         "doctrine": "2.1.0",
         "eslint-scope": "4.0.0",
         "eslint-utils": "1.3.1",
@@ -426,7 +382,7 @@
         "js-yaml": "3.12.0",
         "json-stable-stringify-without-jsonify": "1.0.1",
         "levn": "0.3.0",
-        "lodash": "4.17.10",
+        "lodash": "4.17.11",
         "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
         "natural-compare": "1.4.0",
@@ -441,87 +397,6 @@
         "strip-json-comments": "2.0.1",
         "table": "4.0.3",
         "text-table": "0.2.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.3"
-          }
-        },
-        "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.5.0"
-          }
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "4.17.10",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "3.0.0"
-          }
-        }
       }
     },
     "eslint-scope": {
@@ -674,9 +549,9 @@
       "dev": true
     },
     "glob": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-      "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "1.0.0",
@@ -701,7 +576,7 @@
       "requires": {
         "array-union": "1.0.2",
         "arrify": "1.0.1",
-        "glob": "7.1.1",
+        "glob": "7.1.3",
         "object-assign": "4.1.1",
         "pify": "2.3.0",
         "pinkie-promise": "2.0.1"
@@ -732,12 +607,20 @@
       "dev": true,
       "requires": {
         "ansi-regex": "2.1.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        }
       }
     },
     "has-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
-      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
     "he": {
@@ -795,71 +678,13 @@
         "cli-width": "2.2.0",
         "external-editor": "3.0.3",
         "figures": "2.0.0",
-        "lodash": "4.17.10",
+        "lodash": "4.17.11",
         "mute-stream": "0.0.7",
         "run-async": "2.3.0",
-        "rxjs": "6.3.2",
+        "rxjs": "6.3.3",
         "string-width": "2.1.1",
         "strip-ansi": "4.0.0",
         "through": "2.3.8"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.3"
-          }
-        },
-        "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.5.0"
-          }
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "4.17.10",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "3.0.0"
-          }
-        }
       }
     },
     "is-fullwidth-code-point": {
@@ -955,9 +780,9 @@
       }
     },
     "lodash": {
-      "version": "3.10.1",
-      "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
     },
     "lodash._baseassign": {
@@ -1082,12 +907,58 @@
         "lodash.create": "3.1.1",
         "mkdirp": "0.5.1",
         "supports-color": "3.1.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "glob": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "has-flag": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+          "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+          "dev": true,
+          "requires": {
+            "has-flag": "1.0.0"
+          }
+        }
       }
     },
     "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
       "dev": true
     },
     "mute-stream": {
@@ -1253,7 +1124,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "7.1.1"
+        "glob": "7.1.3"
       }
     },
     "run-async": {
@@ -1266,9 +1137,9 @@
       }
     },
     "rxjs": {
-      "version": "6.3.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.2.tgz",
-      "integrity": "sha512-hV7criqbR0pe7EeL3O66UYVg92IR0XsA97+9y+BWTePK9SKmEI5Qd3Zj6uPnGkNzXsBywBQWTvujPl+1Kn9Zjw==",
+      "version": "6.3.3",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
+      "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
       "dev": true,
       "requires": {
         "tslib": "1.9.3"
@@ -1340,6 +1211,12 @@
         "is-fullwidth-code-point": "2.0.0"
       }
     },
+    "source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -1354,6 +1231,54 @@
       "requires": {
         "chalk": "1.1.3",
         "lodash": "3.10.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "2.2.1",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "2.0.0",
+            "strip-ansi": "3.0.1",
+            "supports-color": "2.0.0"
+          }
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
+        }
       }
     },
     "string-width": {
@@ -1364,32 +1289,15 @@
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
         "strip-ansi": "4.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
-        }
       }
     },
     "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "3.0.0"
       }
     },
     "strip-json-comments": {
@@ -1399,12 +1307,12 @@
       "dev": true
     },
     "supports-color": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-      "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
       "requires": {
-        "has-flag": "1.0.0"
+        "has-flag": "3.0.0"
       }
     },
     "table": {
@@ -1413,55 +1321,12 @@
       "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
       "dev": true,
       "requires": {
-        "ajv": "6.5.3",
+        "ajv": "6.5.4",
         "ajv-keywords": "3.2.0",
         "chalk": "2.4.1",
-        "lodash": "4.17.10",
+        "lodash": "4.17.11",
         "slice-ansi": "1.0.0",
         "string-width": "2.1.1"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.3"
-          }
-        },
-        "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.5.0"
-          }
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
-        "lodash": {
-          "version": "4.17.10",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "3.0.0"
-          }
-        }
       }
     },
     "text-table": {
@@ -1472,7 +1337,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },
@@ -1506,6 +1371,24 @@
       "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
       "dev": true
     },
+    "uglify-js": {
+      "version": "3.4.9",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
+      "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
+      "dev": true,
+      "requires": {
+        "commander": "2.17.1",
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.17.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
+          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
+          "dev": true
+        }
+      }
+    },
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
@@ -1533,7 +1416,7 @@
         "@polymer/polymer": "3.0.5",
         "@polymer/sinonjs": "1.17.1",
         "@polymer/test-fixture": "3.0.0-pre.21",
-        "@webcomponents/webcomponentsjs": "2.1.1",
+        "@webcomponents/webcomponentsjs": "2.1.3",
         "accessibility-developer-tools": "2.12.0",
         "async": "1.5.2",
         "chai": "3.5.0",
@@ -1542,6 +1425,14 @@
         "sinon": "1.17.7",
         "sinon-chai": "2.14.0",
         "stacky": "1.3.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+          "dev": true
+        }
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   },
   "devDependencies": {
     "eslint": "^5.5.0",
-    "uglify-js": "^3.4.9",
     "wct-browser-legacy": "^1.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "eslint": "^5.5.0",
+    "uglify-js": "^3.4.9",
     "wct-browser-legacy": "^1.0.1"
   }
 }

--- a/polymer.json
+++ b/polymer.json
@@ -1,4 +1,5 @@
 {
+  "entrypoint": "html/index.html",
   "extraDependencies": [
     "node_modules/@polymer/polymer/**",
     "node_modules/@webcomponents/webcomponentsjs/**"
@@ -11,7 +12,10 @@
       "html": { "minify": false },
       "css": { "minify": false },
       "js": { "minify": false },
-      "bundle": { "stripComments": true }
+      "bundle": {
+        "inlineScripts": true,
+        "stripComments": true
+      }
     }
   ],
   "moduleResolution": "node",

--- a/polymer.json
+++ b/polymer.json
@@ -9,9 +9,9 @@
       "name": "prod",
       "preset": "es5-bundled",
       "addServiceWorker": false,
-      "html": { "minify": false },
-      "css": { "minify": false },
-      "js": { "minify": false },
+      "html": { "minify": true },
+      "css": { "minify": true },
+      "js": { "minify": true },
       "bundle": {
         "inlineScripts": true,
         "stripComments": true

--- a/polymer.json
+++ b/polymer.json
@@ -6,7 +6,12 @@
   "builds": [
     {
       "name": "prod",
-      "js": {"minify": true}
+      "preset": "es5-bundled",
+      "addServiceWorker": false,
+      "html": { "minify": false },
+      "css": { "minify": false },
+      "js": { "minify": false },
+      "bundle": { "stripComments": true }
     }
   ],
   "moduleResolution": "node",

--- a/src/rise-data-image.js
+++ b/src/rise-data-image.js
@@ -3,7 +3,7 @@ import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 class RiseDataImage extends PolymerElement {
     static get template() {
       return html`
-        <p>Downloading image, please wait...</p>
+        <p>Image test</p>
       `;
     }
 }

--- a/src/rise-data-image.js
+++ b/src/rise-data-image.js
@@ -1,11 +1,34 @@
-import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
+/* eslint-disable no-magic-numbers */
+
+import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 
 class RiseDataImage extends PolymerElement {
-    static get template() {
-      return html`
-        <p>Image test</p>
-      `;
-    }
+  static get properties () {
+    return {
+      url: {
+        type: String,
+        value: ''
+      }
+    };
+  }
+
+  constructor() {
+    super();
+
+    setInterval(() => this.toggleImage(this), 5000);
+  }
+
+  toggleImage(element) {
+    element.url = `/content/${
+      element.url.endsWith('logo.svg') ? 'schedules-icon.png' : 'logo.svg'
+    }`;
+
+    const event = new CustomEvent('url-updated', {
+      bubbles: true, composed: true, detail: { url: element.url }
+    });
+
+    this.dispatchEvent(event);
+  }
 }
 
 customElements.define('rise-data-image', RiseDataImage);

--- a/src/rise-data-image.js
+++ b/src/rise-data-image.js
@@ -15,13 +15,12 @@ class RiseDataImage extends PolymerElement {
   constructor() {
     super();
 
-    setInterval(() => this.toggleImage(this), 5000);
+    setTimeout(() => this.loadImage(this), 5000);
   }
 
-  toggleImage(element) {
-    element.url = `/content/${
-      element.url.endsWith('logo.svg') ? 'schedules-icon.png' : 'logo.svg'
-    }`;
+  loadImage(element) {
+    // fixed for now, URL will be read from local-storage in a later POC
+    element.url = '/content/logo.svg';
 
     const event = new CustomEvent('url-updated', {
       bubbles: true, composed: true, detail: { url: element.url }

--- a/src/rise-data-image.js
+++ b/src/rise-data-image.js
@@ -1,6 +1,11 @@
-import { PolymerElement } from '@polymer/polymer/polymer-element.js';
+import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
 
 class RiseDataImage extends PolymerElement {
+    static get template() {
+      return html`
+        <p>Downloading image, please wait...</p>
+      `;
+    }
 }
 
 customElements.define('rise-data-image', RiseDataImage);


### PR DESCRIPTION
This extracts the web component code to a transpiled and minified format that can be inserted dynamically in an HTML page:

The rise-data-image component now sends an arbitrary event for a fixed file after 5 seconds, just to test that it's working OK. This will be substituted by local-storage URLs in folllowing PRs.
A helper HTML page was created under html/index.html to allow the component to be transpiled, minified and inlined as if it were part of a page.

An extractor script then is run in CCI2 build to extract the fragment corresponding to the component in the compiled page to an independent script file that can be loaded to GCS staging/beta/stable buckets.
