### PR TITLE
Feature/watch image file

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 node_modules/**
 build
+dist

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -183,7 +183,7 @@
         "no-undef-init": "error",
         "no-undef": "off",
         "no-undefined": "error",
-        "no-underscore-dangle": "error",
+        "no-underscore-dangle": "off",
         "no-unmodified-loop-condition": "error",
         "no-unneeded-ternary": "error",
         "no-unused-expressions": "error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -53,7 +53,7 @@
         "consistent-return": "off",
         "consistent-this": "error",
         "curly": "error",
-        "default-case": "error",
+        "default-case": "off",
         "dot-location": "off",
         "dot-notation": [
             "error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -68,7 +68,7 @@
         "func-name-matching": "error",
         "func-names": "off",
         "func-style": "off",
-        "function-paren-newline": "error",
+        "function-paren-newline": "off",
         "generator-star-spacing": "error",
         "getter-return": "error",
         "global-require": "error",

--- a/README.md
+++ b/README.md
@@ -52,14 +52,22 @@ the code above should be: http://localhost:9030/rise-data-image.js
 
 The component must have a unique HTML id with format 'rise-data-image-<NUMBER>'.
 
-The component must have a file attribute with a valid GCS file path.
+The component must have a 'file' attribute with a valid GCS file path.
+
+Example:
+
+`
+<rise-data-image id="rise-data-image-01"
+  file="risemedialibrary-xxxxxx-xxxx-xxxx-xxxx-xxxxxxxx/logo.png">
+</rise-data-image>
+`
 
 ## Events
 
 This component sends the following events:
 
 - image-status-updated: object with properties:
-    - status: "STALE", "CURRRENT", "DELETE" and "NOEXIST" for single files.
+    - status: "STALE", "CURRENT", "DELETE" and "NOEXIST" for single files.
     - file: file being watched
     - url: will only be set if status == 'CURRENT'
 - image-error: object with properties file, errorMessage and errorDetail.

--- a/README.md
+++ b/README.md
@@ -47,3 +47,19 @@ https://github.com/Rise-Vision/content-component-architecture-poc/blob/master/RE
 
 For example, the full referenced component URL for localhost and the port in
 the code above should be: http://localhost:9030/rise-data-image.js
+
+## Attributes
+
+The component must have a unique HTML id with format 'rise-data-image-<NUMBER>'.
+
+The component must have a file attribute with a valid GCS file path.
+
+## Events
+
+This component sends the following events:
+
+- image-status-updated: object with properties:
+    - status: "STALE", "CURRRENT", "DELETE" and "NOEXIST" for single files.
+    - file: file being watched
+    - url: will only be set if status == 'CURRENT'
+- image-error: object with properties file, errorMessage and errorDetail.

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "GPL-3.0+",
   "scripts": {
     "build": "polymer build && ./extract_code.sh rise-data-image",
-    "test": "eslint . && polymer test --npm"
+    "test": "eslint src && eslint test && polymer test --npm"
   },
   "dependencies": {
     "@polymer/polymer": "^3.0.5",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "GPL-3.0+",
   "scripts": {
     "build": "polymer build && ./extract_code.sh rise-data-image",
-    "test": "eslint src && polymer test --npm"
+    "test": "eslint . && polymer test --npm"
   },
   "dependencies": {
     "@polymer/polymer": "^3.0.5",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "GPL-3.0+",
   "scripts": {
     "build": "polymer build && ./extract_code.sh rise-data-image",
-    "test": "eslint src && eslint test && polymer test --npm"
+    "test": "eslint src && polymer test --npm"
   },
   "dependencies": {
     "@polymer/polymer": "^3.0.5",

--- a/src/rise-data-image.js
+++ b/src/rise-data-image.js
@@ -29,20 +29,23 @@ class RiseDataImage extends PolymerElement {
   }
 
   handleSingleFileUpdate(message) {
-    if (!message.available) {
-      this.url = '';
-
-      if (message.error) {
-        return this.sendImageEvent('image-error', {
-          errorMessage: message.errorMessage, errorDetail: message.errorDetail
-        });
-      }
-
-      return this.sendImageEvent('image-not-available');
+    if (!message.status) {
+      return;
     }
 
-    this.url = message.fileUrl;
-    this.sendImageEvent('image-url-updated', { url: this.url });
+    this.url = message.fileUrl || '';
+
+    if (message.status === 'FILE-ERROR') {
+      return this.sendImageEvent('image-error', {
+        file: this.file,
+        errorMessage: message.errorMessage,
+        errorDetail: message.errorDetail
+      });
+    }
+
+    this.sendImageEvent('image-status-updated', {
+      file: this.file, url: this.url, status: message.status
+    });
   }
 
   sendImageEvent(eventName, detail = {}) {

--- a/src/rise-data-image.js
+++ b/src/rise-data-image.js
@@ -23,7 +23,9 @@ class RiseDataImage extends PolymerElement {
 
     // TODO: check license ( JTBD later on this epic )
 
-    watchSingleFile(this.file, message => this.handleUpdate(message));
+    RisePlayerConfiguration.LocalStorage.watchSingleFile(
+      this.file, message => this.handleUpdate(message)
+    );
   }
 
   handleUpdate(message) {
@@ -46,66 +48,6 @@ class RiseDataImage extends PolymerElement {
     this.dispatchEvent(event);
   }
 
-}
-
-// Move to common-templates
-
-function watchSingleFile(filePath, handler) {
-  onceAvailable('local-storage', () =>
-  {
-    const state = {filePath, available: false, error: false};
-
-    RisePlayerConfiguration.LocalMessaging.broadcastMessage({
-      topic: "watch", filePath
-    });
-
-    RisePlayerConfiguration.LocalMessaging.receiveMessages(message => {
-      if (!message || !message.topic) {return;}
-
-      switch (message.topic.toUpperCase()) {
-        case "FILE-UPDATE":
-          return handleFileUpdate(message, state, handler);
-        case "FILE-ERROR":
-          return handleFileError(message, state, handler);
-      }
-    });
-  });
-}
-
-function onceAvailable(modules, action) {
-  // TODO: check if modules available, then activate action.
-
-  action();
-}
-
-function handleFileUpdate(message, state, handler) {
-  if (!message || !message.filePath || !message.status || message.filePath !== state.filePath) {
-    return;
-  }
-
-  const available = message.status.toUpperCase() === "CURRENT";
-
-  // availability hasn't changed, so don't handle
-  if (available === state.available) {return;}
-
-  Object.assign(state, {available, error: false});
-
-  const fileUrl = available ? message.osurl : null;
-
-  handler({ fileUrl, available });
-}
-
-function handleFileError(message, state, handler) {
-  if (!message || !message.filePath) {return;}
-
-  // file is not being watched
-  if (message.filePath !== state.filePath) {return;}
-
-  Object.assign(state, {available, error: true});
-
-  handler({
-    available, error, errorMessage: message.msg, errorDetail: message.detail
-  });
 }
 
 customElements.define('rise-data-image', RiseDataImage);

--- a/src/rise-data-image.js
+++ b/src/rise-data-image.js
@@ -21,19 +21,34 @@ class RiseDataImage extends PolymerElement {
 
     this.file = this.getAttribute('file');
 
-    setTimeout(() => this.loadImage(this), 5000);
+    this.watch(this.file, message => this.handleUpdate(message));
   }
 
-  loadImage(element) {
-    // fixed for now, URL will be read from local-storage in a later POC
-    element.url = element.file;
+  handleUpdate(message) {
+    if (!message.fileUrl) {
+      // file doesn't exist or deleted, handle this
+
+      return;
+    }
+
+    this.loadImage(message.fileUrl);
+  }
+
+  loadImage(url) {
+    this.url = url;
 
     const event = new CustomEvent('url-updated', {
-      bubbles: true, composed: true, detail: { url: element.url }
+      bubbles: true, composed: true, detail: { url }
     });
 
     this.dispatchEvent(event);
   }
+
+  // this will be sent to common-template later
+  watch(filePath, handler) {
+    setTimeout(() => handler({ filePath, fileUrl: this.file }), 5000);
+  }
+
 }
 
 customElements.define('rise-data-image', RiseDataImage);

--- a/src/rise-data-image.js
+++ b/src/rise-data-image.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-magic-numbers, no-warning-comments */
+/* eslint-disable no-warning-comments */
 
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 

--- a/src/rise-data-image.js
+++ b/src/rise-data-image.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-magic-numbers */
+/* eslint-disable no-magic-numbers, no-warning-comments */
 
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 
@@ -21,20 +21,22 @@ class RiseDataImage extends PolymerElement {
 
     this.file = this.getAttribute('file');
 
-    this.watch(this.file, message => this.handleUpdate(message));
+    // TODO: check license ( JTBD later on this epic )
+
+    watchSingleFile(this.file, message => this.handleUpdate(message));
   }
 
   handleUpdate(message) {
-    if (!message.fileUrl) {
+    if (!message.available) {
       // file doesn't exist or deleted, handle this
 
       return;
     }
 
-    this.loadImage(message.fileUrl);
+    this.sendImageUrlUpdatedEvent(message.fileUrl);
   }
 
-  loadImage(url) {
+  sendImageUrlUpdatedEvent(url) {
     this.url = url;
 
     const event = new CustomEvent('url-updated', {
@@ -44,11 +46,66 @@ class RiseDataImage extends PolymerElement {
     this.dispatchEvent(event);
   }
 
-  // this will be sent to common-template later
-  watch(filePath, handler) {
-    setTimeout(() => handler({ filePath, fileUrl: this.file }), 5000);
+}
+
+// Move to common-templates
+
+function watchSingleFile(filePath, handler) {
+  onceAvailable('local-storage', () =>
+  {
+    const state = {filePath, available: false, error: false};
+
+    RisePlayerConfiguration.LocalMessaging.broadcastMessage({
+      topic: "watch", filePath
+    });
+
+    RisePlayerConfiguration.LocalMessaging.receiveMessages(message => {
+      if (!message || !message.topic) {return;}
+
+      switch (message.topic.toUpperCase()) {
+        case "FILE-UPDATE":
+          return handleFileUpdate(message, state, handler);
+        case "FILE-ERROR":
+          return handleFileError(message, state, handler);
+      }
+    });
+  });
+}
+
+function onceAvailable(modules, action) {
+  // TODO: check if modules available, then activate action.
+
+  action();
+}
+
+function handleFileUpdate(message, state, handler) {
+  if (!message || !message.filePath || !message.status || message.filePath !== state.filePath) {
+    return;
   }
 
+  const available = message.status.toUpperCase() === "CURRENT";
+
+  // availability hasn't changed, so don't handle
+  if (available === state.available) {return;}
+
+  Object.assign(state, {available, error: false});
+
+  const fileUrl = available ? message.osurl : null;
+
+  handler({ fileUrl, available });
+}
+
+function handleFileError(message, state, handler) {
+  if (!message || !message.filePath) {return;}
+
+  // file is not being watched
+  if (message.filePath !== state.filePath) {return;}
+
+  Object.assign(state, {available, error: true});
+
+  handler({
+    available, error, errorMessage: message.msg, errorDetail: message.detail
+  });
 }
 
 customElements.define('rise-data-image', RiseDataImage);

--- a/src/rise-data-image.js
+++ b/src/rise-data-image.js
@@ -24,25 +24,30 @@ class RiseDataImage extends PolymerElement {
     // TODO: check license ( JTBD later on this epic )
 
     RisePlayerConfiguration.LocalStorage.watchSingleFile(
-      this.file, message => this.handleUpdate(message)
+      this.file, message => this.handleSingleFileUpdate(message)
     );
   }
 
-  handleUpdate(message) {
+  handleSingleFileUpdate(message) {
     if (!message.available) {
-      // file doesn't exist or deleted, handle this
+      this.url = '';
 
-      return;
+      if (message.error) {
+        return this.sendImageEvent('image-error', {
+          errorMessage: message.errorMessage, errorDetail: message.errorDetail
+        });
+      }
+
+      return this.sendImageEvent('image-not-available');
     }
 
-    this.sendImageUrlUpdatedEvent(message.fileUrl);
+    this.url = message.fileUrl;
+    this.sendImageEvent('image-url-updated', { url: this.url });
   }
 
-  sendImageUrlUpdatedEvent(url) {
-    this.url = url;
-
-    const event = new CustomEvent('url-updated', {
-      bubbles: true, composed: true, detail: { url }
+  sendImageEvent(eventName, detail = {}) {
+    const event = new CustomEvent(eventName, {
+      bubbles: true, composed: true, detail
     });
 
     this.dispatchEvent(event);

--- a/test/unit/rise-data-image-test.html
+++ b/test/unit/rise-data-image-test.html
@@ -53,6 +53,10 @@
           element = fixture('test-block');
         });
 
+        teardown(() => {
+          RisePlayerConfiguration.LocalStorage = {};
+        });
+
         test('it should have a property file', () => {
           assert.equal(element.file, SAMPLE_PATH);
         });

--- a/test/unit/rise-data-image-test.html
+++ b/test/unit/rise-data-image-test.html
@@ -34,6 +34,8 @@
             assert(event.detail.url);
             assert.equal(event.detail.url, SAMPLE_URL);
 
+            assert.equal(element.url, SAMPLE_URL);
+
             done();
           });
         });

--- a/test/unit/rise-data-image-test.html
+++ b/test/unit/rise-data-image-test.html
@@ -62,11 +62,83 @@
         });
 
         test('it should send an URL updated event if an image is available', done => {
-          element.addEventListener('url-updated', event => {
+          element.addEventListener('image-url-updated', event => {
             assert(event.detail.url);
             assert.equal(event.detail.url, SAMPLE_URL);
 
             assert.equal(element.url, SAMPLE_URL);
+
+            done();
+          });
+        });
+      });
+    </script>
+
+    <script>
+      suite('rise-data-image image not available', () => {
+        let element;
+
+        setup(() => {
+          RisePlayerConfiguration.LocalStorage = {
+            watchSingleFile: (file, handler) => {
+              setTimeout(
+                () => handler({ available: false }), 1000
+              );
+            }
+          };
+
+          element = fixture('test-block');
+        });
+
+        teardown(() => {
+          RisePlayerConfiguration.LocalStorage = {};
+        });
+
+        test('it should send an image not available event if an image is not available', done => {
+          element.addEventListener('image-not-available', event => {
+            assert(!event.detail.url);
+            assert(!element.url);
+
+            done();
+          });
+        });
+      });
+    </script>
+
+    <script>
+      suite('rise-data-image image error', () => {
+        let element;
+
+        setup(() => {
+          RisePlayerConfiguration.LocalStorage = {
+            watchSingleFile: (file, handler) => {
+              setTimeout(
+                () => handler({
+                  available: false,
+                  error: true,
+                  errorMessage: "image download error",
+                  errorDetail: "network failure"
+                }), 1000
+              );
+            }
+          };
+
+          element = fixture('test-block');
+        });
+
+        teardown(() => {
+          RisePlayerConfiguration.LocalStorage = {};
+        });
+
+        test('it should send an image not available event if an image is not available', done => {
+          element.addEventListener('image-error', event => {
+            assert(!event.detail.url);
+            assert(!element.url);
+
+            assert.deepEqual( event.detail, {
+              errorMessage: "image download error",
+              errorDetail: "network failure"
+            });
 
             done();
           });

--- a/test/unit/rise-data-image-test.html
+++ b/test/unit/rise-data-image-test.html
@@ -130,7 +130,7 @@
           RisePlayerConfiguration.LocalStorage = {};
         });
 
-        test('it should send an image not available event if an image is not available', done => {
+        test('it should send an image error event if an image local storage error was received', done => {
           element.addEventListener('image-error', event => {
             assert(!event.detail.url);
             assert(!element.url);

--- a/test/unit/rise-data-image-test.html
+++ b/test/unit/rise-data-image-test.html
@@ -8,19 +8,21 @@
     <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
     <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
     <script>
-      const SAMPLE_URL =
-        'https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png';
+      const SAMPLE_PATH = 'risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png';
+      const SAMPLE_URL = `https://storage.googleapis.com/${ SAMPLE_PATH }`;
 
       RisePlayerConfiguration = {
         LocalMessaging: {
           broadcastMessage: () => {},
           receiveMessages: handler => {
-            setTimeout(() => handler({
-              topic: "FILE-UPDATE",
-              filePath: SAMPLE_URL,
-              status: "CURRENT",
-              osurl: SAMPLE_URL
-            }), 1000);
+            setTimeout(() =>
+              handler({
+                topic: "FILE-UPDATE",
+                filePath: SAMPLE_URL,
+                status: "CURRENT",
+                osurl: SAMPLE_URL
+              }), 1000
+            );
           }
         }
       };
@@ -30,7 +32,7 @@
   <body>
     <test-fixture id="test-block">
       <template>
-        <rise-data-image file="https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png">
+        <rise-data-image file="risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png">
         </rise-data-image>
       </template>
     </test-fixture>
@@ -39,13 +41,23 @@
       suite('rise-data-image', () => {
         let element;
 
-        setup(() => element = fixture('test-block'));
+        setup(() => {
+          RisePlayerConfiguration.LocalStorage = {
+            watchSingleFile: (file, handler) => {
+              setTimeout(
+                () => handler({ available: true, fileUrl: SAMPLE_URL }), 1000
+              );
+            }
+          };
 
-        test('it should have a property file', () => {
-          assert.equal(element.file, SAMPLE_URL);
+          element = fixture('test-block');
         });
 
-        test('it should send an URL updated event', done => {
+        test('it should have a property file', () => {
+          assert.equal(element.file, SAMPLE_PATH);
+        });
+
+        test('it should send an URL updated event if an image is available', done => {
           element.addEventListener('url-updated', event => {
             assert(event.detail.url);
             assert.equal(event.detail.url, SAMPLE_URL);

--- a/test/unit/rise-data-image-test.html
+++ b/test/unit/rise-data-image-test.html
@@ -31,7 +31,7 @@
           RisePlayerConfiguration.LocalStorage = {
             watchSingleFile: (file, handler) => {
               setTimeout(
-                () => handler({ available: true, fileUrl: SAMPLE_URL }), 1000
+                () => handler({ status: "CURRENT", fileUrl: SAMPLE_URL }), 1000
               );
             }
           };
@@ -47,10 +47,11 @@
           assert.equal(element.file, SAMPLE_PATH);
         });
 
-        test('it should send an URL updated event if an image is available', done => {
-          element.addEventListener('image-url-updated', event => {
-            assert(event.detail.url);
-            assert.equal(event.detail.url, SAMPLE_URL);
+        test('it should send an image updated event if an image is available', done => {
+          element.addEventListener('image-status-updated', event => {
+            assert.deepEqual(event.detail, {
+              status: "CURRENT", url: SAMPLE_URL, file: SAMPLE_PATH
+            });
 
             assert.equal(element.url, SAMPLE_URL);
 
@@ -68,7 +69,7 @@
           RisePlayerConfiguration.LocalStorage = {
             watchSingleFile: (file, handler) => {
               setTimeout(
-                () => handler({ available: false }), 1000
+                () => handler({ status: "NOEXIST" }), 1000
               );
             }
           };
@@ -80,9 +81,12 @@
           RisePlayerConfiguration.LocalStorage = {};
         });
 
-        test('it should send an image not available event if an image is not available', done => {
-          element.addEventListener('image-not-available', event => {
-            assert(!event.detail.url);
+        test('it should send an image updated event with NOEXIST status if an image does not exist', done => {
+          element.addEventListener('image-status-updated', event => {
+            assert.deepEqual(event.detail, {
+              status: "NOEXIST", file: SAMPLE_PATH, url: ""
+            });
+
             assert(!element.url);
 
             done();
@@ -100,8 +104,8 @@
             watchSingleFile: (file, handler) => {
               setTimeout(
                 () => handler({
-                  available: false,
-                  error: true,
+                  fileUrl: null,
+                  status: "FILE-ERROR",
                   errorMessage: "image download error",
                   errorDetail: "network failure"
                 }), 1000
@@ -118,10 +122,10 @@
 
         test('it should send an image error event if an image local storage error was received', done => {
           element.addEventListener('image-error', event => {
-            assert(!event.detail.url);
             assert(!element.url);
 
             assert.deepEqual( event.detail, {
+              file: SAMPLE_PATH,
               errorMessage: "image download error",
               errorDetail: "network failure"
             });

--- a/test/unit/rise-data-image-test.html
+++ b/test/unit/rise-data-image-test.html
@@ -7,6 +7,24 @@
 
     <script src="../../node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
     <script src="../../node_modules/wct-browser-legacy/browser.js"></script>
+    <script>
+      const SAMPLE_URL =
+        'https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png';
+
+      RisePlayerConfiguration = {
+        LocalMessaging: {
+          broadcastMessage: () => {},
+          receiveMessages: handler => {
+            setTimeout(() => handler({
+              topic: "FILE-UPDATE",
+              filePath: SAMPLE_URL,
+              status: "CURRENT",
+              osurl: SAMPLE_URL
+            }), 1000);
+          }
+        }
+      };
+    </script>
     <script src="../../src/rise-data-image.js" type="module"></script>
   </head>
   <body>
@@ -19,8 +37,6 @@
 
     <script>
       suite('rise-data-image', () => {
-        const SAMPLE_URL =
-          'https://storage.googleapis.com/risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png';
         let element;
 
         setup(() => element = fixture('test-block'));

--- a/test/unit/rise-data-image-test.html
+++ b/test/unit/rise-data-image-test.html
@@ -11,21 +11,7 @@
       const SAMPLE_PATH = 'risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png';
       const SAMPLE_URL = `https://storage.googleapis.com/${ SAMPLE_PATH }`;
 
-      RisePlayerConfiguration = {
-        LocalMessaging: {
-          broadcastMessage: () => {},
-          receiveMessages: handler => {
-            setTimeout(() =>
-              handler({
-                topic: "FILE-UPDATE",
-                filePath: SAMPLE_URL,
-                status: "CURRENT",
-                osurl: SAMPLE_URL
-              }), 1000
-            );
-          }
-        }
-      };
+      RisePlayerConfiguration = {};
     </script>
     <script src="../../src/rise-data-image.js" type="module"></script>
   </head>


### PR DESCRIPTION
Uses RisePlayerConfiguration.LocalStorage.watchSingleFile method to listen to availability changes and errors in the configured image file, and sends events depending on those:
- image-url-updated
- image-not-available
- image-error

This was tested manually on player electron using this branch:

https://github.com/Rise-Vision/content-component-architecture-poc/compare/chore/use_local_messaging?expand=1
