### PR TITLE
Chore/deploy beta stable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,9 +83,7 @@ jobs:
           VERSION=$(cat version-string/version)
           TARGET=$GS_BASE/staging/components/$COMPONENT_NAME/$VERSION/
           echo Deploying version $VERSION to $COMPONENT_NAME
-          gsutil cp dist/$COMPONENT_NAME.js $TARGET
-          gsutil -m setmeta -r -h "Cache-Control:private, max-age=0" $TARGET
-          gsutil acl -r ch -u AllUsers:R $TARGET
+          ./upload_to_gcs.sh $COMPONENT_NAME $TARGET
 
   deploy-production:
     parameters:
@@ -104,9 +102,7 @@ jobs:
           GS_BASE=gs://widgets.risevision.com
           TARGET=$GS_BASE/<< parameters.stage >>/components/$COMPONENT_NAME/
           echo Deploying << parameters.stage >> version of $COMPONENT_NAME
-          gsutil cp dist/*.js $TARGET
-          gsutil -m setmeta -r -h "Cache-Control:private, max-age=0" $TARGET
-          gsutil acl -r ch -u AllUsers:R $TARGET
+          ./upload_to_gcs.sh $COMPONENT_NAME $TARGET
 
 workflows:
   workflow1:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,7 +155,6 @@ workflows:
           filters:
             branches:
               only:
-                - /^(stage|staging)[/].*/
                 - master
       - deploy-production:
           stage: stable

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 
 jobs:
   preconditions:
@@ -87,7 +87,10 @@ jobs:
           gsutil -m setmeta -r -h "Cache-Control:private, max-age=0" $TARGET
           gsutil acl -r ch -u AllUsers:R $TARGET
 
-  deploy-beta:
+  deploy-production:
+    parameters:
+      stage:
+        type: string
     docker: *GCSIMAGE
     steps:
       - checkout
@@ -97,22 +100,15 @@ jobs:
           key: node-cache-{{ checksum "package.json" }}
       - run: mkdir -p ~/.config
       - run: cp -r gcloud ~/.config
-      - run: echo beta $(cat version-string/version)
-
-  deploy-stable:
-    docker: *GCSIMAGE
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - restore_cache:
-          key: node-cache-{{ checksum "package.json" }}
-      - run: mkdir -p ~/.config
-      - run: cp -r gcloud ~/.config
-      - run: echo stable $(cat version-string/version)
+      - run: |
+          GS_BASE=gs://widgets.risevision.com
+          TARGET=$GS_BASE/<< parameters.stage >>/components/$COMPONENT_NAME/
+          echo Deploying << parameters.stage >> version of $COMPONENT_NAME
+          gsutil cp dist/*.js $TARGET
+          gsutil -m setmeta -r -h "Cache-Control:private, max-age=0" $TARGET
+          gsutil acl -r ch -u AllUsers:R $TARGET
 
 workflows:
-  version: 2
   workflow1:
     jobs:
       - preconditions
@@ -154,7 +150,8 @@ workflows:
                 - /^(stage|staging)[/].*/
                 - master
                 - build/stable
-      - deploy-beta:
+      - deploy-production:
+          stage: beta
           requires:
             - gcloud-setup
             - generate-version
@@ -162,8 +159,10 @@ workflows:
           filters:
             branches:
               only:
+                - /^(stage|staging)[/].*/
                 - master
-      - deploy-stable:
+      - deploy-production:
+          stage: stable
           requires:
             - gcloud-setup
             - generate-version

--- a/upload_to_gcs.sh
+++ b/upload_to_gcs.sh
@@ -1,0 +1,6 @@
+COMPONENT_NAME=$1
+TARGET=$2
+
+gsutil cp dist/$COMPONENT_NAME.js $TARGET
+gsutil -m setmeta -r -h "Cache-Control:private, max-age=0" $TARGET
+gsutil acl -r ch -u AllUsers:R $TARGET


### PR DESCRIPTION
This deploys:
- to beta on master branch
- to stable on build/stable branch

I extracted the common gsutil commands to an external script for code reuse

I tested manually, and got a published script to beta here:
https://console.cloud.google.com/storage/browser/widgets.risevision.com/beta/components/rise-data-image/?project=avid-life-623
