### PR TITLE
run e2e tests for player-electron

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,8 +151,6 @@ jobs:
 
   test-e2e-electron:
     parameters:
-      stage:
-        type: string
       displayId:
         type: string
     docker: &E2EIMAGE
@@ -282,7 +280,6 @@ workflows:
               only:
                 - build/stable
       - test-e2e-electron:
-          stage: beta
           displayId: 9YP68DHZ4HUJ
           name: test-e2e-electron-beta
           requires:
@@ -293,7 +290,6 @@ workflows:
               only:
                 - master
       - test-e2e-electron:
-          stage: stable
           displayId: U2SQ87Y5QM64
           name: test-e2e-electron-stable
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,7 +220,6 @@ workflows:
             branches:
               only:
                 - master
-                - /^(stage|staging)[/].*/
       - build-e2e-page:
           stage: stable
           name: build-e2e-page-stable
@@ -252,7 +251,6 @@ workflows:
             branches:
               only:
                 - master
-                - /^(stage|staging)[/].*/
       - deploy-e2e-page:
           stage: stable
           name: deploy-e2e-page-stable
@@ -273,7 +271,6 @@ workflows:
             branches:
               only:
                 - master
-                - /^(stage|staging)[/].*/
       - test-e2e-electron:
           displayId: U2SQ87Y5QM64
           name: test-e2e-electron-stable
@@ -293,7 +290,6 @@ workflows:
             branches:
               only:
                 - master
-                - /^(stage|staging)[/].*/
       - deploy-production:
           stage: stable
           name: deploy-stable

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,31 +44,6 @@ jobs:
           paths:
             - dist
 
-  build-e2e-page:
-    parameters:
-      stage:
-        type: string
-    docker: *BUILDIMAGE
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - restore_cache:
-          key: node-cache-{{ checksum "package.json" }}
-      - run: echo build e2e page << parameters.stage >>
-      - run: |
-          sed '
-            s/__STAGE__/<< parameters.stage >>/;
-            s/__PLAYER__/electron/;
-            s/__CONNECTION__/websocket/;
-          ' e2e/rise-data-image.html > e2e/rise-data-image-electron.html
-      - run: cp e2e/polymer-e2e-electron.json polymer.json
-      - run: polymer build
-      - persist_to_workspace:
-          root: ./build
-          paths:
-            - base
-
   gcloud-setup:
     docker: &GCSIMAGE
       - image: jenkinsrise/cci-v2-launcher-electron:0.0.6
@@ -95,6 +70,33 @@ jobs:
           paths:
             - version-string
 
+  build-e2e-page:
+    parameters:
+      stage:
+        type: string
+    docker: *BUILDIMAGE
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - restore_cache:
+          key: node-cache-{{ checksum "package.json" }}
+      - run: echo build e2e page << parameters.stage >>
+      - run: |
+          VERSION=$(cat version-string/version)
+          sed "
+            s/__STAGE__/<< parameters.stage >>/;
+            s/__VERSION__/$VERSION/;
+            s/__PLAYER__/electron/;
+            s/__CONNECTION__/websocket/;
+          " e2e/rise-data-image.html > e2e/rise-data-image-electron.html
+      - run: cp e2e/polymer-e2e-electron.json polymer.json
+      - run: polymer build
+      - persist_to_workspace:
+          root: ./build
+          paths:
+            - base
+
   deploy-stage:
     docker: *GCSIMAGE
     steps:
@@ -109,24 +111,6 @@ jobs:
           VERSION=$(cat version-string/version)
           TARGET=$WIDGETS_BASE/staging/components/$COMPONENT_NAME/$VERSION/
           echo Deploying version $VERSION to $COMPONENT_NAME
-          node_modules/common-component/deploy-gcs.sh $COMPONENT_NAME $TARGET
-
-  deploy-production:
-    parameters:
-      stage:
-        type: string
-    docker: *GCSIMAGE
-    steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - restore_cache:
-          key: node-cache-{{ checksum "package.json" }}
-      - run: mkdir -p ~/.config
-      - run: cp -r gcloud ~/.config
-      - run: |
-          TARGET=$WIDGETS_BASE/<< parameters.stage >>/components/$COMPONENT_NAME/
-          echo Deploying << parameters.stage >> version of $COMPONENT_NAME
           node_modules/common-component/deploy-gcs.sh $COMPONENT_NAME $TARGET
 
   deploy-e2e-page:
@@ -177,6 +161,24 @@ jobs:
       - store_artifacts:
           path: output
 
+  deploy-production:
+    parameters:
+      stage:
+        type: string
+    docker: *GCSIMAGE
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - restore_cache:
+          key: node-cache-{{ checksum "package.json" }}
+      - run: mkdir -p ~/.config
+      - run: cp -r gcloud ~/.config
+      - run: |
+          TARGET=$WIDGETS_BASE/<< parameters.stage >>/components/$COMPONENT_NAME/
+          echo Deploying << parameters.stage >> version of $COMPONENT_NAME
+          node_modules/common-component/deploy-gcs.sh $COMPONENT_NAME $TARGET
+
 workflows:
   workflow1:
     jobs:
@@ -213,15 +215,18 @@ workflows:
           name: build-e2e-page-beta
           requires:
             - build
+            - generate-version
           filters:
             branches:
               only:
                 - master
+                - /^(stage|staging)[/].*/
       - build-e2e-page:
           stage: stable
           name: build-e2e-page-stable
           requires:
             - build
+            - generate-version
           filters:
             branches:
               only:
@@ -237,28 +242,6 @@ workflows:
                 - /^(stage|staging)[/].*/
                 - master
                 - build/stable
-      - deploy-production:
-          stage: beta
-          name: deploy-beta
-          requires:
-            - gcloud-setup
-            - generate-version
-            - build
-          filters:
-            branches:
-              only:
-                - master
-      - deploy-production:
-          stage: stable
-          name: deploy-stable
-          requires:
-            - gcloud-setup
-            - generate-version
-            - build
-          filters:
-            branches:
-              only:
-                - build/stable
       - deploy-e2e-page:
           stage: beta
           name: deploy-e2e-page-beta
@@ -269,6 +252,7 @@ workflows:
             branches:
               only:
                 - master
+                - /^(stage|staging)[/].*/
       - deploy-e2e-page:
           stage: stable
           name: deploy-e2e-page-stable
@@ -283,18 +267,38 @@ workflows:
           displayId: 9YP68DHZ4HUJ
           name: test-e2e-electron-beta
           requires:
-            - deploy-beta
+            - deploy-stage
             - deploy-e2e-page-beta
           filters:
             branches:
               only:
                 - master
+                - /^(stage|staging)[/].*/
       - test-e2e-electron:
           displayId: U2SQ87Y5QM64
           name: test-e2e-electron-stable
           requires:
-            - deploy-stable
+            - deploy-stage
             - deploy-e2e-page-stable
+          filters:
+            branches:
+              only:
+                - build/stable
+      - deploy-production:
+          stage: beta
+          name: deploy-beta
+          requires:
+            - test-e2e-electron-beta
+          filters:
+            branches:
+              only:
+                - master
+                - /^(stage|staging)[/].*/
+      - deploy-production:
+          stage: stable
+          name: deploy-stable
+          requires:
+            - test-e2e-electron-stable
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,8 @@ jobs:
   gcloud-setup:
     docker: &GCSIMAGE
       - image: jenkinsrise/cci-v2-launcher-electron:0.0.6
+        environment:
+          WIDGETS_BASE: gs://widgets.risevision.com
     steps:
       - run: mkdir -p ~/.ssh
       - run: ssh-keyscan -H github.com >> ~/.ssh/known_hosts
@@ -104,9 +106,8 @@ jobs:
       - run: mkdir -p ~/.config
       - run: cp -r gcloud ~/.config
       - run: |
-          GS_BASE=gs://widgets.risevision.com
           VERSION=$(cat version-string/version)
-          TARGET=$GS_BASE/staging/components/$COMPONENT_NAME/$VERSION/
+          TARGET=$WIDGETS_BASE/staging/components/$COMPONENT_NAME/$VERSION/
           echo Deploying version $VERSION to $COMPONENT_NAME
           node_modules/common-component/deploy-gcs.sh $COMPONENT_NAME $TARGET
 
@@ -124,8 +125,7 @@ jobs:
       - run: mkdir -p ~/.config
       - run: cp -r gcloud ~/.config
       - run: |
-          GS_BASE=gs://widgets.risevision.com
-          TARGET=$GS_BASE/<< parameters.stage >>/components/$COMPONENT_NAME/
+          TARGET=$WIDGETS_BASE/<< parameters.stage >>/components/$COMPONENT_NAME/
           echo Deploying << parameters.stage >> version of $COMPONENT_NAME
           node_modules/common-component/deploy-gcs.sh $COMPONENT_NAME $TARGET
 
@@ -143,25 +143,41 @@ jobs:
       - run: mkdir -p ~/.config
       - run: cp -r gcloud ~/.config
       - run: |
-          GS_BASE=gs://widgets.risevision.com
-          TARGET=$GS_BASE/<< parameters.stage >>/e2e/$COMPONENT_NAME/electron
+          TARGET=$WIDGETS_BASE/<< parameters.stage >>/e2e/$COMPONENT_NAME/electron
           echo Deploying << parameters.stage >> electron e2e page for $COMPONENT_NAME
           gsutil rsync -d -r base $TARGET
           gsutil -m setmeta -r -h "Cache-Control:private, max-age=0" $TARGET
           gsutil acl -r ch -u AllUsers:R $TARGET
 
-  test-e2e:
+  test-e2e-electron:
     parameters:
       stage:
         type: string
-    docker: *GCSIMAGE
+      displayId:
+        type: string
+    docker: &E2EIMAGE
+      - image: jenkinsrise/jenkinsrise-cci-image-launcher-electron-e2e:0.0.2
+        environment:
+          SCREENSHOTS_BASE: https://storage.googleapis.com/risevision-display-screenshots
+          PLAYER_CONFIG: /home/circleci/rvplayer/RiseDisplayNetworkII.ini
     steps:
-      - checkout
-      - attach_workspace:
-          at: .
-      - restore_cache:
-          key: node-cache-{{ checksum "package.json" }}
-      - run: echo testing e2e << parameters.stage >>
+      - run: git clone https://github.com/Rise-Vision/rise-launcher-electron-e2e.git
+      - run: |
+          cd rise-launcher-electron-e2e
+          npm install
+      - run: mkdir ~/rvplayer
+      - run: echo "displayid=<< parameters.displayId >>" > $PLAYER_CONFIG
+      - run: echo proxy= >> $PLAYER_CONFIG
+      - run:
+          name: run the test
+          command: |
+            EXPECTED_SNAPSHOT_URL=$SCREENSHOTS_BASE/<< parameters.displayId >>.jpg
+            cd rise-launcher-electron-e2e
+            node test-display-runner.js << parameters.displayId >> $EXPECTED_SNAPSHOT_URL 20
+      - run: mkdir output
+      - run: mv ./rise-launcher-electron-e2e/*screenshot.jpg output
+      - store_artifacts:
+          path: output
 
 workflows:
   workflow1:
@@ -265,9 +281,10 @@ workflows:
             branches:
               only:
                 - build/stable
-      - test-e2e:
+      - test-e2e-electron:
           stage: beta
-          name: test-e2e-beta
+          displayId: 9YP68DHZ4HUJ
+          name: test-e2e-electron-beta
           requires:
             - deploy-beta
             - deploy-e2e-page-beta
@@ -275,9 +292,10 @@ workflows:
             branches:
               only:
                 - master
-      - test-e2e:
+      - test-e2e-electron:
           stage: stable
-          name: test-e2e-stable
+          displayId: U2SQ87Y5QM64
+          name: test-e2e-electron-stable
           requires:
             - deploy-stable
             - deploy-e2e-page-stable

--- a/e2e/rise-data-image.html
+++ b/e2e/rise-data-image.html
@@ -18,8 +18,15 @@
     <script src="https://widgets.risevision.com/__STAGE__/common/rise-local-messaging.js"></script>
     <script src="https://widgets.risevision.com/__STAGE__/common/rise-helpers.js"></script>
     <script src="https://widgets.risevision.com/__STAGE__/common/rise-local-storage.js"></script>
-    <script src="https://widgets.risevision.com/__STAGE__/common/rise-component-loader.js"></script>
+    <script src="https://widgets.risevision.com/staging/common/2018.10.11.09.00/rise-component-loader.js"></script>
     <script>
+      RisePlayerConfiguration.ComponentLoader.components = [
+        {
+          name: "rise-data-image",
+          url: "https://widgets.risevision.com/staging/components/rise-data-image/__VERSION__/rise-data-image.js"
+        }
+      ];
+
       if (document.domain.indexOf("localhost") === -1) {
         try {
           document.domain = "risevision.com";

--- a/e2e/rise-data-image.html
+++ b/e2e/rise-data-image.html
@@ -18,7 +18,7 @@
     <script src="https://widgets.risevision.com/__STAGE__/common/rise-local-messaging.js"></script>
     <script src="https://widgets.risevision.com/__STAGE__/common/rise-helpers.js"></script>
     <script src="https://widgets.risevision.com/__STAGE__/common/rise-local-storage.js"></script>
-    <script src="https://widgets.risevision.com/staging/common/2018.10.11.09.00/rise-component-loader.js"></script>
+    <script src="https://widgets.risevision.com/__STAGE__/common/rise-component-loader.js"></script>
     <script>
       RisePlayerConfiguration.ComponentLoader.components = [
         {


### PR DESCRIPTION
This runs the e2e player-electron tests on beta and stable branchs. It compares an expected snapshot from those taken directly from the image being run.

Example of the beta run here:
https://circleci.com/workflow-run/ff32068a-e826-4093-b86f-e9d1bc8446aa

The beta and stable uses different display ids / schedules, so they can point to different published URLs for the test page.

Additional changes:
- rename GS_BASE to WIDGETS_BASE and extract it as a variable for the whole container.
- rename test-e2e to test-e2e-electron, as this is the type of environment being tested. I'll also explore testing the chrome-os player with the chrome app. If it's doable I'll create another PR later for that.

NOTE: currently the test-display-runner.js script depends on getRemoteManifest() that always returns the path for the stable version of electron player:
https://github.com/Rise-Vision/rise-launcher-electron-e2e/blob/master/test-display-runner.js#L15
https://github.com/Rise-Vision/rise-launcher-electron-e2e/blob/master/downloader.js#L44

For components, it's defined that beta components will run on beta versions of player and stable components will run on stable versions of player; but I'm not sure if that should be reflected in the e2e tests here. My suggestion is to, at least for the time being, leave the stable version for these tests; but we could also modify these scripts to consider the player version to be tested if needed.
