### PR TITLE
Chore/use beta electron player on e2e beta

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,7 +222,6 @@ workflows:
             branches:
               only:
                 - master
-                - /^(stage|staging)[/].*/
       - build-e2e-page:
           stage: stable
           name: build-e2e-page-stable
@@ -254,7 +253,6 @@ workflows:
             branches:
               only:
                 - master
-                - /^(stage|staging)[/].*/
       - deploy-e2e-page:
           stage: stable
           name: deploy-e2e-page-stable
@@ -276,7 +274,6 @@ workflows:
             branches:
               only:
                 - master
-                - /^(stage|staging)[/].*/
       - test-e2e-electron:
           stage: stable
           displayId: U2SQ87Y5QM64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,8 +148,6 @@ jobs:
       - run: git clone https://github.com/Rise-Vision/rise-launcher-electron-e2e.git
       - run: |
           cd rise-launcher-electron-e2e
-          git checkout -b feature/support_beta_player_in_test_display_runner
-          git pull origin feature/support_beta_player_in_test_display_runner
           npm install
       - run: mkdir ~/rvplayer
       - run: echo "displayid=<< parameters.displayId >>" > $PLAYER_CONFIG

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,6 +135,8 @@ jobs:
 
   test-e2e-electron:
     parameters:
+      stage:
+        type: string
       displayId:
         type: string
     docker: &E2EIMAGE
@@ -146,6 +148,8 @@ jobs:
       - run: git clone https://github.com/Rise-Vision/rise-launcher-electron-e2e.git
       - run: |
           cd rise-launcher-electron-e2e
+          git checkout -b feature/support_beta_player_in_test_display_runner
+          git pull origin feature/support_beta_player_in_test_display_runner
           npm install
       - run: mkdir ~/rvplayer
       - run: echo "displayid=<< parameters.displayId >>" > $PLAYER_CONFIG
@@ -155,7 +159,7 @@ jobs:
           command: |
             EXPECTED_SNAPSHOT_URL=$SCREENSHOTS_BASE/<< parameters.displayId >>.jpg
             cd rise-launcher-electron-e2e
-            node test-display-runner.js << parameters.displayId >> $EXPECTED_SNAPSHOT_URL 20
+            node test-display-runner.js << parameters.displayId >> $EXPECTED_SNAPSHOT_URL 20 << parameters.stage >>
       - run: mkdir output
       - run: mv ./rise-launcher-electron-e2e/*screenshot.jpg output
       - store_artifacts:
@@ -220,6 +224,7 @@ workflows:
             branches:
               only:
                 - master
+                - /^(stage|staging)[/].*/
       - build-e2e-page:
           stage: stable
           name: build-e2e-page-stable
@@ -251,6 +256,7 @@ workflows:
             branches:
               only:
                 - master
+                - /^(stage|staging)[/].*/
       - deploy-e2e-page:
           stage: stable
           name: deploy-e2e-page-stable
@@ -262,6 +268,7 @@ workflows:
               only:
                 - build/stable
       - test-e2e-electron:
+          stage: beta
           displayId: 9YP68DHZ4HUJ
           name: test-e2e-electron-beta
           requires:
@@ -271,7 +278,9 @@ workflows:
             branches:
               only:
                 - master
+                - /^(stage|staging)[/].*/
       - test-e2e-electron:
+          stage: stable
           displayId: U2SQ87Y5QM64
           name: test-e2e-electron-stable
           requires:


### PR DESCRIPTION
This passes either "stable" or "beta" parameter to the e2e script that was changed here:
https://github.com/Rise-Vision/rise-launcher-electron-e2e/pull/47/files#diff-fc1b20682386780ebaf0b4a1b152c121R5

Example of full testing on beta here:
https://circleci.com/workflow-run/cb7dcd1c-297d-4be4-88a8-082dad18e6ca
