### PR TITLE
Fix/demo page and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # rise-data-image
 
-Web component that retrieves image data
+Web component that retrieves image data.
+
+Instructions for demo page here:
+https://github.com/Rise-Vision/rise-data-image/blob/master/demo/README.md
 
 ## Build instructions
 
@@ -15,7 +18,7 @@ npm run build
 ```
 
 **Note**: If EPERM errors occur then install polymer-cli using the
-`--unsafe-perm` flag ( `npm install -g polymer-cli --unsafe-perm` ) 
+`--unsafe-perm` flag ( `npm install -g polymer-cli --unsafe-perm` )
 and/or using sudo.
 
 ## Test instructions

--- a/demo/README.md
+++ b/demo/README.md
@@ -39,10 +39,11 @@ To do this all the contents of build/prod may be uploaded to GCS,
 with public permissions and no caching. To avoid CORS issues, the server
 domain of the published file must be risevision.com.
 
-Then create a schedule that points to the published file, for example
-( note that this is an HTTP URL, as ChromeOS currently requires that ):
+Then create a schedule that points to the published file, for example:
 
   http://widgets.risevision.com/staging/pages/2018.XX.XX.XX.XX/src/rise-data-image-chromeos.html
+
+Note that this is an HTTP URL, as ChromeOS currently requires that.
 
 Then configure the local environment as described in the
 [Financial Templates First - Local Development](https://docs.google.com/document/d/1xbtDo9GnhbH0lGeQmgTdSb-U5ed0vTjufhxZBV-1C4A/edit)

--- a/demo/README.md
+++ b/demo/README.md
@@ -44,11 +44,10 @@ Then create a schedule that points to the published file, for example
 
   http://widgets.risevision.com/staging/pages/2018.XX.XX.XX.XX/src/rise-data-image-chromeos.html
 
-Then configure the local environment as described in the following document
-( it's not necessary to point the schedule to a local URL as it's described
-there, with the above URL for the schedule is enough ):
-
-  https://docs.google.com/document/d/1xbtDo9GnhbH0lGeQmgTdSb-U5ed0vTjufhxZBV-1C4A/edit
+Then configure the local environment as described in the
+[Financial Templates First - Local Development](https://docs.google.com/document/d/1xbtDo9GnhbH0lGeQmgTdSb-U5ed0vTjufhxZBV-1C4A/edit)
+document. It's not necessary to point the schedule to a local URL as it's
+described there, with the above URL for the schedule is enough.
 
 Once the application has been configured and ran, an image referenced as the
 file attribute in the rise-data-image tag should appear after a few seconds.

--- a/demo/README.md
+++ b/demo/README.md
@@ -36,13 +36,17 @@ This option is the most convenient if one does not want to install a local
 copy of the Electron Player.
 
 To do this all the contents of build/prod may be uploaded to GCS,
-with public permissions and no caching.
+with public permissions and no caching. To avoid CORS issues, the server
+domain of the published file must be risevision.com.
 
-Then create a schedule that points to the published file, for example:
+Then create a schedule that points to the published file, for example
+( note that this is an HTTP URL, as ChromeOS currently requires that ):
 
-  https://storage.googleapis.com/risemedialibrary-xxxxx-yyyy-xxx/src/rise-data-image-chromeos.html
+  http://widgets.risevision.com/staging/pages/2018.XX.XX.XX.XX/src/rise-data-image-chromeos.html
 
-Then configure the local environment as described in the following document:
+Then configure the local environment as described in the following document
+( it's not necessary to point the schedule to a local URL as it's described
+there, with the above URL for the schedule is enough ):
 
   https://docs.google.com/document/d/1xbtDo9GnhbH0lGeQmgTdSb-U5ed0vTjufhxZBV-1C4A/edit
 

--- a/demo/src/rise-data-image-chromeos.html
+++ b/demo/src/rise-data-image-chromeos.html
@@ -14,13 +14,13 @@
     <script type="module">
       import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
     </script>
-    <script src="http://widgets.risevision.com/beta/common/config-test.js"></script>
-    <script src="http://widgets.risevision.com/beta/common/rise-player-configuration.js"></script>
-    <script src="http://widgets.risevision.com/beta/common/rise-local-messaging.js"></script>
-    <script src="http://widgets.risevision.com/beta/common/rise-helpers.js"></script>
-    <script src="http://widgets.risevision.com/beta/common/rise-logger.js"></script>
-    <script src="http://widgets.risevision.com/beta/common/rise-local-storage.js"></script>
-    <script src="http://widgets.risevision.com/beta/common/rise-component-loader.js"></script>
+    <script src="https://widgets.risevision.com/beta/common/config-test.js"></script>
+    <script src="https://widgets.risevision.com/beta/common/rise-player-configuration.js"></script>
+    <script src="https://widgets.risevision.com/beta/common/rise-local-messaging.js"></script>
+    <script src="https://widgets.risevision.com/beta/common/rise-helpers.js"></script>
+    <script src="https://widgets.risevision.com/beta/common/rise-logger.js"></script>
+    <script src="https://widgets.risevision.com/beta/common/rise-local-storage.js"></script>
+    <script src="https://widgets.risevision.com/beta/common/rise-component-loader.js"></script>
     <script>
       // remove the following sentence if you are combining rise-data-image with rise-financial beta
       RisePlayerConfiguration.ComponentLoader.components = [

--- a/demo/src/rise-data-image-chromeos.html
+++ b/demo/src/rise-data-image-chromeos.html
@@ -14,13 +14,13 @@
     <script type="module">
       import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
     </script>
-    <script src="https://widgets.risevision.com/beta/common/config-test.js"></script>
-    <script src="https://widgets.risevision.com/beta/common/rise-player-configuration.js"></script>
-    <script src="https://widgets.risevision.com/beta/common/rise-local-messaging.js"></script>
-    <script src="https://widgets.risevision.com/beta/common/rise-helpers.js"></script>
-    <script src="https://widgets.risevision.com/beta/common/rise-logger.js"></script>
-    <script src="https://widgets.risevision.com/beta/common/rise-local-storage.js"></script>
-    <script src="https://widgets.risevision.com/beta/common/rise-component-loader.js"></script>
+    <script src="http://widgets.risevision.com/beta/common/config-test.js"></script>
+    <script src="http://widgets.risevision.com/beta/common/rise-player-configuration.js"></script>
+    <script src="http://widgets.risevision.com/beta/common/rise-local-messaging.js"></script>
+    <script src="http://widgets.risevision.com/beta/common/rise-helpers.js"></script>
+    <script src="http://widgets.risevision.com/beta/common/rise-logger.js"></script>
+    <script src="http://widgets.risevision.com/beta/common/rise-local-storage.js"></script>
+    <script src="http://widgets.risevision.com/beta/common/rise-component-loader.js"></script>
     <script>
       // remove the following sentence if you are combining rise-data-image with rise-financial beta
       RisePlayerConfiguration.ComponentLoader.components = [


### PR DESCRIPTION
Demo page for ChromeOS needs to use HTTP, and the README file should also mention that HTTP should be used for ChromeOS.

I also added the requirement for risevision.com domain for demo pages, and some clarifications for instructions that resulted in confusion.
