### PR TITLE
Fix/fixes issue 17

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,7 +235,6 @@ workflows:
             branches:
               only:
                 - master
-                - /^(stage|staging)[/].*/
       - build-e2e-page:
           stage: stable
           name: build-e2e-page-stable
@@ -265,7 +264,6 @@ workflows:
             branches:
               only:
                 - master
-                - /^(stage|staging)[/].*/
       - deploy-e2e-page:
           stage: stable
           name: deploy-e2e-page-stable
@@ -287,7 +285,6 @@ workflows:
             branches:
               only:
                 - master
-                - /^(stage|staging)[/].*/
       - test-e2e-electron:
           stage: stable
           displayId: U2SQ87Y5QM64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,11 +231,11 @@ workflows:
           name: build-e2e-page-beta
           requires:
             - build
-            - /^(stage|staging)[/].*/
           filters:
             branches:
               only:
                 - master
+                - /^(stage|staging)[/].*/
       - build-e2e-page:
           stage: stable
           name: build-e2e-page-stable

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -231,6 +231,7 @@ workflows:
           name: build-e2e-page-beta
           requires:
             - build
+            - /^(stage|staging)[/].*/
           filters:
             branches:
               only:
@@ -264,6 +265,7 @@ workflows:
             branches:
               only:
                 - master
+                - /^(stage|staging)[/].*/
       - deploy-e2e-page:
           stage: stable
           name: deploy-e2e-page-stable
@@ -285,6 +287,7 @@ workflows:
             branches:
               only:
                 - master
+                - /^(stage|staging)[/].*/
       - test-e2e-electron:
           stage: stable
           displayId: U2SQ87Y5QM64

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
+demo/node_modules/**
 node_modules/**
 build
 dist

--- a/demo/src/rise-data-image-chromeos.html
+++ b/demo/src/rise-data-image-chromeos.html
@@ -21,14 +21,10 @@
     <script src="https://widgets.risevision.com/beta/common/rise-logger.js"></script>
     <script src="https://widgets.risevision.com/beta/common/rise-local-storage.js"></script>
     <script src="https://widgets.risevision.com/beta/common/rise-component-loader.js"></script>
+    <script src="https://widgets.risevision.com/beta/components/rise-data-image/rise-data-image.js"></script>
     <script>
       // remove the following sentence if you are combining rise-data-image with rise-financial beta
-      RisePlayerConfiguration.ComponentLoader.components = [
-        {
-          name: "rise-data-image",
-          url: "https://widgets.risevision.com/beta/components/rise-data-image/rise-data-image.js"
-        }
-      ];
+      RisePlayerConfiguration.ComponentLoader.components = [];
 
       if (document.domain.indexOf("localhost") === -1) {
         try {
@@ -39,6 +35,18 @@
         }
       }
     </script>
+  </head>
+  <body>
+    <rise-data-image id="rise-data-image-01"
+      file="risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png">
+    </rise-data-image>
+
+    <div id="image01">
+      <p>Downloading image, please wait...</p>
+    </div>
+
+    <hr>
+
     <script>
       function configureComponents(event) {
         if ( !event.detail.isLoaded ) {
@@ -86,16 +94,5 @@
         connectionType: "window"
       });
     </script>
-  </head>
-  <body>
-    <rise-data-image id="rise-data-image-01"
-      file="risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png">
-    </rise-data-image>
-
-    <div id="image01">
-      <p>Downloading image, please wait...</p>
-    </div>
-
-    <hr>
   </body>
 </html>

--- a/demo/src/rise-data-image-chromeos.html
+++ b/demo/src/rise-data-image-chromeos.html
@@ -15,12 +15,7 @@
       import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
     </script>
     <script src="https://widgets.risevision.com/beta/common/config-test.js"></script>
-    <script src="https://widgets.risevision.com/beta/common/rise-player-configuration.js"></script>
-    <script src="https://widgets.risevision.com/beta/common/rise-local-messaging.js"></script>
-    <script src="https://widgets.risevision.com/beta/common/rise-helpers.js"></script>
-    <script src="https://widgets.risevision.com/beta/common/rise-logger.js"></script>
-    <script src="https://widgets.risevision.com/beta/common/rise-local-storage.js"></script>
-    <script src="https://widgets.risevision.com/beta/common/rise-component-loader.js"></script>
+    <script src="https://widgets.risevision.com/beta/common/common-template.js"></script>
     <script src="https://widgets.risevision.com/beta/components/rise-data-image/rise-data-image.js"></script>
     <script>
       // remove the following sentence if you are combining rise-data-image with rise-financial beta

--- a/demo/src/rise-data-image-chromeos.html
+++ b/demo/src/rise-data-image-chromeos.html
@@ -63,9 +63,10 @@
           `;
         });
 
-        setTimeout(function() {
-          image01.dispatchEvent( new CustomEvent( "start" ) );
-        }, 1000);
+        image01.addEventListener('configured', () =>
+          image01.dispatchEvent( new CustomEvent( "start" ) )
+        );
+        image01.dispatchEvent( new CustomEvent( "start" ) );
       }
 
       window.addEventListener( "rise-components-loaded", configureComponents );

--- a/demo/src/rise-data-image-chromeos.html
+++ b/demo/src/rise-data-image-chromeos.html
@@ -63,7 +63,9 @@
           `;
         });
 
-        image01.dispatchEvent( new CustomEvent( "start" ) );
+        setTimeout(function() {
+          image01.dispatchEvent( new CustomEvent( "start" ) );
+        }, 1000);
       }
 
       window.addEventListener( "rise-components-loaded", configureComponents );

--- a/demo/src/rise-data-image-chromeos.html
+++ b/demo/src/rise-data-image-chromeos.html
@@ -66,6 +66,10 @@
           `;
         });
 
+        // Start the component once it's configured;
+        // but if it's already configured the listener won't work,
+        // so we directly send the request also.
+        // In the future, we may encapsulate the following lines in a helper function.
         image01.addEventListener('configured', () =>
           image01.dispatchEvent( new CustomEvent( "start" ) )
         );

--- a/demo/src/rise-data-image-chromeos.html
+++ b/demo/src/rise-data-image-chromeos.html
@@ -62,6 +62,8 @@
             <p>image error: ${ event.detail.errorMessage }</p>
           `;
         });
+
+        element.dispatchEvent( new CustomEvent( "start" ) );
       }
 
       window.addEventListener( "rise-components-loaded", configureComponents );

--- a/demo/src/rise-data-image-chromeos.html
+++ b/demo/src/rise-data-image-chromeos.html
@@ -63,7 +63,7 @@
           `;
         });
 
-        element.dispatchEvent( new CustomEvent( "start" ) );
+        image01.dispatchEvent( new CustomEvent( "start" ) );
       }
 
       window.addEventListener( "rise-components-loaded", configureComponents );

--- a/demo/src/rise-data-image-electron.html
+++ b/demo/src/rise-data-image-electron.html
@@ -21,7 +21,7 @@
     <script src="https://widgets.risevision.com/beta/common/rise-logger.js"></script>
     <script src="https://widgets.risevision.com/beta/common/rise-local-storage.js"></script>
     <script src="https://widgets.risevision.com/beta/common/rise-component-loader.js"></script>
-    <script src="https://widgets.risevision.com/beta/components/rise-data-image/rise-data-image.js"></script>
+    <script src="https://widgets.risevision.com/staging/components/rise-data-image/2018.10.31.13.26/rise-data-image.js"></script>
     <script>
       // remove the following sentence if you are combining rise-data-image with rise-financial beta
       RisePlayerConfiguration.ComponentLoader.components = [];
@@ -71,10 +71,13 @@
           `;
         });
 
-        image01.addEventListener('configured', () =>
-          image01.dispatchEvent( new CustomEvent( "start" ) )
-        );
+        console.log("page configure start");
+        image01.addEventListener('configured', () => {
+          console.log("configured received");
+          image01.dispatchEvent( new CustomEvent( "start" ) );
+        });
         image01.dispatchEvent( new CustomEvent( "start" ) );
+        console.log("page configure start");
       }
 
       window.addEventListener( "rise-components-loaded", configureComponents );

--- a/demo/src/rise-data-image-electron.html
+++ b/demo/src/rise-data-image-electron.html
@@ -15,12 +15,7 @@
       import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
     </script>
     <script src="https://widgets.risevision.com/beta/common/config-test.js"></script>
-    <script src="https://widgets.risevision.com/beta/common/rise-player-configuration.js"></script>
-    <script src="https://widgets.risevision.com/beta/common/rise-local-messaging.js"></script>
-    <script src="https://widgets.risevision.com/beta/common/rise-helpers.js"></script>
-    <script src="https://widgets.risevision.com/beta/common/rise-logger.js"></script>
-    <script src="https://widgets.risevision.com/beta/common/rise-local-storage.js"></script>
-    <script src="https://widgets.risevision.com/beta/common/rise-component-loader.js"></script>
+    <script src="https://widgets.risevision.com/beta/common/common-template.js"></script>
     <script src="https://widgets.risevision.com/beta/components/rise-data-image/rise-data-image.js"></script>
     <script>
       // remove the following sentence if you are combining rise-data-image with rise-financial beta

--- a/demo/src/rise-data-image-electron.html
+++ b/demo/src/rise-data-image-electron.html
@@ -63,9 +63,10 @@
           `;
         });
 
-        setTimeout(function() {
-          image01.dispatchEvent( new CustomEvent( "start" ) );
-        }, 1000);
+        image01.addEventListener('configured', () =>
+          image01.dispatchEvent( new CustomEvent( "start" ) )
+        );
+        image01.dispatchEvent( new CustomEvent( "start" ) );
       }
 
       window.addEventListener( "rise-components-loaded", configureComponents );

--- a/demo/src/rise-data-image-electron.html
+++ b/demo/src/rise-data-image-electron.html
@@ -63,7 +63,9 @@
           `;
         });
 
-        image01.dispatchEvent( new CustomEvent( "start" ) );
+        setTimeout(function() {
+          image01.dispatchEvent( new CustomEvent( "start" ) );
+        }, 1000);
       }
 
       window.addEventListener( "rise-components-loaded", configureComponents );

--- a/demo/src/rise-data-image-electron.html
+++ b/demo/src/rise-data-image-electron.html
@@ -21,14 +21,10 @@
     <script src="https://widgets.risevision.com/beta/common/rise-logger.js"></script>
     <script src="https://widgets.risevision.com/beta/common/rise-local-storage.js"></script>
     <script src="https://widgets.risevision.com/beta/common/rise-component-loader.js"></script>
+    <script src="https://widgets.risevision.com/beta/components/rise-data-image/rise-data-image.js"></script>
     <script>
       // remove the following sentence if you are combining rise-data-image with rise-financial beta
-      RisePlayerConfiguration.ComponentLoader.components = [
-        {
-          name: "rise-data-image",
-          url: "https://widgets.risevision.com/beta/components/rise-data-image/rise-data-image.js"
-        }
-      ];
+      RisePlayerConfiguration.ComponentLoader.components = [];
 
       if (document.domain.indexOf("localhost") === -1) {
         try {
@@ -39,6 +35,18 @@
         }
       }
     </script>
+  </head>
+  <body>
+    <rise-data-image id="rise-data-image-01"
+      file="risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png">
+    </rise-data-image>
+
+    <div id="image01">
+      <p>Downloading image, please wait...</p>
+    </div>
+
+    <hr>
+
     <script>
       function configureComponents(event) {
         if ( !event.detail.isLoaded ) {
@@ -87,16 +95,5 @@
         detail: { serverUrl: "http://localhost:8080" }
       });
     </script>
-  </head>
-  <body>
-    <rise-data-image id="rise-data-image-01"
-      file="risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png">
-    </rise-data-image>
-
-    <div id="image01">
-      <p>Downloading image, please wait...</p>
-    </div>
-
-    <hr>
   </body>
 </html>

--- a/demo/src/rise-data-image-electron.html
+++ b/demo/src/rise-data-image-electron.html
@@ -66,6 +66,10 @@
           `;
         });
 
+        // Start the component once it's configured;
+        // but if it's already configured the listener won't work,
+        // so we directly send the request also.
+        // In the future, we may encapsulate the following lines in a helper function.
         image01.addEventListener('configured', () =>
           image01.dispatchEvent( new CustomEvent( "start" ) )
         );

--- a/demo/src/rise-data-image-electron.html
+++ b/demo/src/rise-data-image-electron.html
@@ -62,6 +62,8 @@
             <p>image error: ${ event.detail.errorMessage }</p>
           `;
         });
+
+        element.dispatchEvent( new CustomEvent( "start" ) );
       }
 
       window.addEventListener( "rise-components-loaded", configureComponents );

--- a/demo/src/rise-data-image-electron.html
+++ b/demo/src/rise-data-image-electron.html
@@ -63,7 +63,7 @@
           `;
         });
 
-        element.dispatchEvent( new CustomEvent( "start" ) );
+        image01.dispatchEvent( new CustomEvent( "start" ) );
       }
 
       window.addEventListener( "rise-components-loaded", configureComponents );

--- a/demo/src/rise-data-image-electron.html
+++ b/demo/src/rise-data-image-electron.html
@@ -21,7 +21,7 @@
     <script src="https://widgets.risevision.com/beta/common/rise-logger.js"></script>
     <script src="https://widgets.risevision.com/beta/common/rise-local-storage.js"></script>
     <script src="https://widgets.risevision.com/beta/common/rise-component-loader.js"></script>
-    <script src="https://widgets.risevision.com/staging/components/rise-data-image/2018.10.31.13.26/rise-data-image.js"></script>
+    <script src="https://widgets.risevision.com/beta/components/rise-data-image/rise-data-image.js"></script>
     <script>
       // remove the following sentence if you are combining rise-data-image with rise-financial beta
       RisePlayerConfiguration.ComponentLoader.components = [];
@@ -71,13 +71,10 @@
           `;
         });
 
-        console.log("page configure start");
-        image01.addEventListener('configured', () => {
-          console.log("configured received");
-          image01.dispatchEvent( new CustomEvent( "start" ) );
-        });
+        image01.addEventListener('configured', () =>
+          image01.dispatchEvent( new CustomEvent( "start" ) )
+        );
         image01.dispatchEvent( new CustomEvent( "start" ) );
-        console.log("page configure start");
       }
 
       window.addEventListener( "rise-components-loaded", configureComponents );

--- a/e2e/rise-data-image.html
+++ b/e2e/rise-data-image.html
@@ -54,6 +54,8 @@
             <p>image error: ${ event.detail.errorMessage }</p>
           `;
         });
+
+        image01.dispatchEvent( new CustomEvent( "start" ) );
       }
 
       function fetchAndConfigureComponents(event) {

--- a/e2e/rise-data-image.html
+++ b/e2e/rise-data-image.html
@@ -55,7 +55,9 @@
           `;
         });
 
-        image01.dispatchEvent( new CustomEvent( "start" ) );
+        setTimeout(function() {
+          image01.dispatchEvent( new CustomEvent( "start" ) );
+        }, 1000);
       }
 
       function fetchAndConfigureComponents(event) {

--- a/e2e/rise-data-image.html
+++ b/e2e/rise-data-image.html
@@ -15,12 +15,7 @@
       import { PolymerElement, html } from '@polymer/polymer/polymer-element.js';
     </script>
     <script src="https://widgets.risevision.com/__STAGE__/common/config-test.js"></script>
-    <script src="https://widgets.risevision.com/__STAGE__/common/rise-player-configuration.js"></script>
-    <script src="https://widgets.risevision.com/__STAGE__/common/rise-local-messaging.js"></script>
-    <script src="https://widgets.risevision.com/__STAGE__/common/rise-helpers.js"></script>
-    <script src="https://widgets.risevision.com/__STAGE__/common/rise-logger.js"></script>
-    <script src="https://widgets.risevision.com/__STAGE__/common/rise-local-storage.js"></script>
-    <script src="https://widgets.risevision.com/__STAGE__/common/rise-component-loader.js"></script>
+    <script src="https://widgets.risevision.com/__STAGE__/common/common-template.js"></script>
     <script src="https://widgets.risevision.com/staging/components/rise-data-image/__VERSION__/rise-data-image.js"></script>
     <script>
       RisePlayerConfiguration.ComponentLoader.components = [];

--- a/e2e/rise-data-image.html
+++ b/e2e/rise-data-image.html
@@ -55,9 +55,10 @@
           `;
         });
 
-        setTimeout(function() {
-          image01.dispatchEvent( new CustomEvent( "start" ) );
-        }, 1000);
+        image01.addEventListener('configured', () =>
+          image01.dispatchEvent( new CustomEvent( "start" ) )
+        );
+        image01.dispatchEvent( new CustomEvent( "start" ) );
       }
 
       function fetchAndConfigureComponents(event) {

--- a/e2e/rise-data-image.html
+++ b/e2e/rise-data-image.html
@@ -34,6 +34,18 @@
         }
       }
     </script>
+  </head>
+  <body>
+    <rise-data-image id="rise-data-image-01"
+      file="risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png">
+    </rise-data-image>
+
+    <div id="image01">
+      <p>Downloading image, please wait...</p>
+    </div>
+
+    <hr>
+
     <script>
       function configureComponents() {
         // all of the following will be implemented later by a rise-image component
@@ -85,16 +97,5 @@
         detail: { serverUrl: "http://localhost:8080" }
       });
     </script>
-  </head>
-  <body>
-    <rise-data-image id="rise-data-image-01"
-      file="risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png">
-    </rise-data-image>
-
-    <div id="image01">
-      <p>Downloading image, please wait...</p>
-    </div>
-
-    <hr>
   </body>
 </html>

--- a/e2e/rise-data-image.html
+++ b/e2e/rise-data-image.html
@@ -70,10 +70,12 @@
           `;
         });
 
+        console.log("page configure start");
         image01.addEventListener('configured', () =>
           image01.dispatchEvent( new CustomEvent( "start" ) )
         );
         image01.dispatchEvent( new CustomEvent( "start" ) );
+        console.log("page configure end");
       }
 
       window.addEventListener( "rise-components-loaded", configureComponents );

--- a/e2e/rise-data-image.html
+++ b/e2e/rise-data-image.html
@@ -21,13 +21,9 @@
     <script src="https://widgets.risevision.com/__STAGE__/common/rise-logger.js"></script>
     <script src="https://widgets.risevision.com/__STAGE__/common/rise-local-storage.js"></script>
     <script src="https://widgets.risevision.com/__STAGE__/common/rise-component-loader.js"></script>
+    <script src="https://widgets.risevision.com/staging/components/rise-data-image/__VERSION__/rise-data-image.js"></script>
     <script>
-      RisePlayerConfiguration.ComponentLoader.components = [
-        {
-          name: "rise-data-image",
-          url: "https://widgets.risevision.com/staging/components/rise-data-image/__VERSION__/rise-data-image.js"
-        }
-      ];
+      RisePlayerConfiguration.ComponentLoader.components = [];
 
       if (document.domain.indexOf("localhost") === -1) {
         try {

--- a/e2e/rise-data-image.html
+++ b/e2e/rise-data-image.html
@@ -47,7 +47,14 @@
     <hr>
 
     <script>
-      function configureComponents() {
+      function configureComponents(event) {
+        if ( !event.detail.isLoaded ) {
+          console.log( "load process failed" );
+          return;
+        }
+
+        console.log( "manual component configuration" );
+
         // all of the following will be implemented later by a rise-image component
         let image01 = document.querySelector('#rise-data-image-01');
         image01.addEventListener('image-status-updated', event => {
@@ -69,17 +76,7 @@
         image01.dispatchEvent( new CustomEvent( "start" ) );
       }
 
-      function fetchAndConfigureComponents(event) {
-        if ( !event.detail.isLoaded ) {
-          console.log( "load process failed" );
-          return;
-        }
-
-        console.log( "manual configuration" );
-        configureComponents();
-      }
-
-      window.addEventListener( "rise-components-loaded", fetchAndConfigureComponents );
+      window.addEventListener( "rise-components-loaded", configureComponents );
     </script>
     <script>
       console.log("configuring");

--- a/e2e/rise-data-image.html
+++ b/e2e/rise-data-image.html
@@ -70,12 +70,10 @@
           `;
         });
 
-        console.log("page configure start");
         image01.addEventListener('configured', () =>
           image01.dispatchEvent( new CustomEvent( "start" ) )
         );
         image01.dispatchEvent( new CustomEvent( "start" ) );
-        console.log("page configure end");
       }
 
       window.addEventListener( "rise-components-loaded", configureComponents );

--- a/src/rise-data-image.js
+++ b/src/rise-data-image.js
@@ -45,13 +45,12 @@ class RiseDataImage extends PolymerElement {
     console.log("component ready start");
     super.ready();
 
-    console.log("component ready start");
-    this._sendImageEvent(RiseDataImage.EVENT_CONFIGURED);
     this.addEventListener(
       RiseDataImage.EVENT_START,
       () => this._handleStart(),
       { once: true }
     );
+    this._sendImageEvent(RiseDataImage.EVENT_CONFIGURED);
     console.log("component ready end");
   }
 

--- a/src/rise-data-image.js
+++ b/src/rise-data-image.js
@@ -18,6 +18,10 @@ class RiseDataImage extends PolymerElement {
   }
 
   // Event name constants
+  static get EVENT_CONFIGURED() {
+    return "configured";
+  }
+
   static get EVENT_IMAGE_ERROR() {
     return "image-error";
   }
@@ -35,6 +39,7 @@ class RiseDataImage extends PolymerElement {
 
     this.file = this.getAttribute('file');
 
+    this._sendImageEvent(RiseDataImage.EVENT_CONFIGURED);
     this.addEventListener(
       RiseDataImage.EVENT_START,
       () => this._handleStart(),

--- a/src/rise-data-image.js
+++ b/src/rise-data-image.js
@@ -26,20 +26,32 @@ class RiseDataImage extends PolymerElement {
     return "image-status-updated";
   }
 
+  static get EVENT_START() {
+    return "start";
+  }
+
   constructor() {
     super();
 
     this.file = this.getAttribute('file');
 
+    this.addEventListener(
+      RiseDataImage.EVENT_START,
+      () => this._handleStart(),
+      { once: true }
+    );
+  }
+
+  _handleStart() {
     // TODO: check license ( JTBD later on this epic )
 
     RisePlayerConfiguration.LocalStorage.watchSingleFile(
-      this.file, message => this.handleSingleFileUpdate(message)
+      this.file, message => this._handleSingleFileUpdate(message)
     );
     console.log("version is: ", version); // eslint-disable-line no-console
   }
 
-  handleSingleFileUpdate(message) {
+  _handleSingleFileUpdate(message) {
     if (!message.status) {
       return;
     }
@@ -47,19 +59,19 @@ class RiseDataImage extends PolymerElement {
     this.url = message.fileUrl || '';
 
     if (message.status === 'FILE-ERROR') {
-      return this.sendImageEvent(RiseDataImage.EVENT_IMAGE_ERROR, {
+      return this._sendImageEvent(RiseDataImage.EVENT_IMAGE_ERROR, {
         file: this.file,
         errorMessage: message.errorMessage,
         errorDetail: message.errorDetail
       });
     }
 
-    this.sendImageEvent(RiseDataImage.EVENT_IMAGE_STATUS_UPDATED, {
+    this._sendImageEvent(RiseDataImage.EVENT_IMAGE_STATUS_UPDATED, {
       file: this.file, url: this.url, status: message.status
     });
   }
 
-  sendImageEvent(eventName, detail = {}) {
+  _sendImageEvent(eventName, detail = {}) {
     const event = new CustomEvent(eventName, {
       bubbles: true, composed: true, detail
     });

--- a/src/rise-data-image.js
+++ b/src/rise-data-image.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-warning-comments */
+/* eslint-disable no-console, no-warning-comments */
 
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { version } from "./rise-data-image-version.js";
@@ -38,17 +38,21 @@ class RiseDataImage extends PolymerElement {
     super();
 
     this.file = this.getAttribute('file');
+    console.log("constructor");
   }
 
   ready() {
+    console.log("component ready start");
     super.ready();
 
+    console.log("component ready start");
     this._sendImageEvent(RiseDataImage.EVENT_CONFIGURED);
     this.addEventListener(
       RiseDataImage.EVENT_START,
       () => this._handleStart(),
       { once: true }
     );
+    console.log("component ready end");
   }
 
   _handleStart() {

--- a/src/rise-data-image.js
+++ b/src/rise-data-image.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-console, no-warning-comments */
+/* eslint-disable no-warning-comments */
 
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { version } from "./rise-data-image-version.js";
@@ -38,11 +38,9 @@ class RiseDataImage extends PolymerElement {
     super();
 
     this.file = this.getAttribute('file');
-    console.log("constructor");
   }
 
   ready() {
-    console.log("component ready start");
     super.ready();
 
     this.addEventListener(
@@ -51,7 +49,6 @@ class RiseDataImage extends PolymerElement {
       { once: true }
     );
     this._sendImageEvent(RiseDataImage.EVENT_CONFIGURED);
-    console.log("component ready end");
   }
 
   _handleStart() {

--- a/src/rise-data-image.js
+++ b/src/rise-data-image.js
@@ -38,6 +38,10 @@ class RiseDataImage extends PolymerElement {
     super();
 
     this.file = this.getAttribute('file');
+  }
+
+  ready() {
+    super.ready();
 
     this._sendImageEvent(RiseDataImage.EVENT_CONFIGURED);
     this.addEventListener(

--- a/src/rise-data-image.js
+++ b/src/rise-data-image.js
@@ -17,6 +17,15 @@ class RiseDataImage extends PolymerElement {
     };
   }
 
+  // Event name constants
+  static get EVENT_IMAGE_ERROR() {
+    return "image-error";
+  }
+
+  static get EVENT_IMAGE_STATUS_UPDATED() {
+    return "image-status-updated";
+  }
+
   constructor() {
     super();
 
@@ -38,14 +47,14 @@ class RiseDataImage extends PolymerElement {
     this.url = message.fileUrl || '';
 
     if (message.status === 'FILE-ERROR') {
-      return this.sendImageEvent('image-error', {
+      return this.sendImageEvent(RiseDataImage.EVENT_IMAGE_ERROR, {
         file: this.file,
         errorMessage: message.errorMessage,
         errorDetail: message.errorDetail
       });
     }
 
-    this.sendImageEvent('image-status-updated', {
+    this.sendImageEvent(RiseDataImage.EVENT_IMAGE_STATUS_UPDATED, {
       file: this.file, url: this.url, status: message.status
     });
   }

--- a/test/unit/rise-data-image-test.html
+++ b/test/unit/rise-data-image-test.html
@@ -57,6 +57,8 @@
 
             done();
           });
+
+          element.dispatchEvent( new CustomEvent( "start" ) );
         });
       });
     </script>
@@ -91,6 +93,8 @@
 
             done();
           });
+
+          element.dispatchEvent( new CustomEvent( "start" ) );
         });
       });
     </script>
@@ -132,6 +136,8 @@
 
             done();
           });
+
+          element.dispatchEvent( new CustomEvent( "start" ) );
         });
       });
     </script>

--- a/test/unit/rise-data-image-test.html
+++ b/test/unit/rise-data-image-test.html
@@ -58,6 +58,9 @@
             done();
           });
 
+          element.addEventListener('configured', () =>
+            element.dispatchEvent( new CustomEvent( "start" ) )
+          );
           element.dispatchEvent( new CustomEvent( "start" ) );
         });
       });
@@ -94,6 +97,9 @@
             done();
           });
 
+          element.addEventListener('configured', () =>
+            element.dispatchEvent( new CustomEvent( "start" ) )
+          );
           element.dispatchEvent( new CustomEvent( "start" ) );
         });
       });
@@ -137,6 +143,9 @@
             done();
           });
 
+          element.addEventListener('configured', () =>
+            element.dispatchEvent( new CustomEvent( "start" ) )
+          );
           element.dispatchEvent( new CustomEvent( "start" ) );
         });
       });


### PR DESCRIPTION
- I now start a watch when the 'started' event is sent. This way, the event listeners are all registered before the component starts working.
- But to avoid further timing problems now I had to add a timer before sending the event. This is because the component sometimes seems to be initializing after the loading scripts are run. 
Maybe a cleaner solution is adding a two-way event, but maybe the current proposal is good enough for the time being because the way the script is loaded will change soon.

I tested manually with image only, manually with financial and image, and also ran the e2e. The problem was no longer present.

I also:
- added static methods for event constants, to emulate what rise-data-financial does
- added underscore prefix to private methods, also for consistency between projects
