### PR TITLE
Fix CCI e2e workflow issue by pre-downloading installer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,9 +162,18 @@ jobs:
       - run:
           name: run the test
           command: |
+            if [ << parameters.stage >> = "beta" ]
+            then
+              INSTALLER_STAGE="beta/"
+            else
+              INSTALLER_STAGE=""
+            fi
             EXPECTED_SNAPSHOT_URL=$SCREENSHOTS_BASE/<< parameters.displayId >>.jpg
             cd rise-launcher-electron-e2e
-            node test-display-runner.js << parameters.displayId >> $EXPECTED_SNAPSHOT_URL 20 << parameters.stage >>
+            curl $EXPECTED_SNAPSHOT_URL > expected-screenshot.jpg
+            curl https://storage.googleapis.com/install-versions.risevision.com/{$INSTALLER_STAGE}installer-lnx-64.sh > installer.sh
+            chmod +x installer.sh
+            node test-display-runner-using-downloaded-installer.js << parameters.displayId >> 20
       - run: mkdir output
       - run: mv ./rise-launcher-electron-e2e/*screenshot.jpg output
       - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,6 +146,8 @@ jobs:
         type: string
       displayId:
         type: string
+      installerPath:
+        type: string
     docker: &E2EIMAGE
       - image: jenkinsrise/jenkinsrise-cci-image-launcher-electron-e2e:0.0.2
         environment:
@@ -160,19 +162,17 @@ jobs:
       - run: echo "displayid=<< parameters.displayId >>" > $PLAYER_CONFIG
       - run: echo proxy= >> $PLAYER_CONFIG
       - run:
-          name: run the test
+          name: prepare the test
           command: |
-            if [ << parameters.stage >> = "beta" ]
-            then
-              INSTALLER_STAGE="beta/"
-            else
-              INSTALLER_STAGE=""
-            fi
             EXPECTED_SNAPSHOT_URL=$SCREENSHOTS_BASE/<< parameters.displayId >>.jpg
             cd rise-launcher-electron-e2e
             curl $EXPECTED_SNAPSHOT_URL > expected-screenshot.jpg
-            curl https://storage.googleapis.com/install-versions.risevision.com/{$INSTALLER_STAGE}installer-lnx-64.sh > installer.sh
+            curl << parameters.installerPath >>installer-lnx-64.sh > installer.sh
             chmod +x installer.sh
+      - run:
+          name: run the test
+          command: |
+            cd rise-launcher-electron-e2e
             node test-display-runner-using-downloaded-installer.js << parameters.displayId >> 20
       - run: mkdir output
       - run: mv ./rise-launcher-electron-e2e/*screenshot.jpg output
@@ -286,6 +286,7 @@ workflows:
       - test-e2e-electron:
           stage: beta
           displayId: 9YP68DHZ4HUJ
+          installerPath: https://storage.googleapis.com/install-versions.risevision.com/beta/
           name: test-e2e-electron-beta
           requires:
             - deploy-stage
@@ -297,6 +298,7 @@ workflows:
       - test-e2e-electron:
           stage: stable
           displayId: U2SQ87Y5QM64
+          installerPath: https://storage.googleapis.com/install-versions.risevision.com/
           name: test-e2e-electron-stable
           requires:
             - deploy-stage


### PR DESCRIPTION
- Same fix as applied to common-template - https://github.com/Rise-Vision/common-template/pull/30