### PR TITLE
Fix/timing issue

### DIFF
--- a/src/rise-data-image.js
+++ b/src/rise-data-image.js
@@ -47,8 +47,7 @@ class RiseDataImage extends PolymerElement {
   ready() {
     super.ready();
 
-    const handleStart = RisePlayerConfiguration.isPreview() ?
-      this._handleStartForPreview : this._handleStart;
+    const handleStart = this._handleStart;
 
     this.addEventListener( RiseDataImage.EVENT_START, handleStart, {
       once: true
@@ -87,6 +86,10 @@ class RiseDataImage extends PolymerElement {
   }
 
   _handleStart() {
+    if ( RisePlayerConfiguration.isPreview()) {
+      return this._handleStartForPreview();
+    }
+
     // TODO: check license ( JTBD later on this epic )
 
     this._logInfo( RiseDataImage.EVENT_START );

--- a/src/rise-data-image.js
+++ b/src/rise-data-image.js
@@ -47,7 +47,7 @@ class RiseDataImage extends PolymerElement {
   ready() {
     super.ready();
 
-    const handleStart = this._handleStart;
+    const handleStart = () => this._handleStart();
 
     this.addEventListener( RiseDataImage.EVENT_START, handleStart, {
       once: true

--- a/src/rise-data-image.js
+++ b/src/rise-data-image.js
@@ -53,7 +53,6 @@ class RiseDataImage extends PolymerElement {
       once: true
     });
 
-    this._logInfo( RiseDataImage.EVENT_CONFIGURED );
     this._sendImageEvent( RiseDataImage.EVENT_CONFIGURED );
   }
 

--- a/test/integration/rise-data-image-logging.html
+++ b/test/integration/rise-data-image-logging.html
@@ -10,7 +10,7 @@
     <script>
         const SAMPLE_PATH = "risemedialibrary-30007b45-3df0-4c7b-9f7f-7d8ce6443013/logo.png";
         const SAMPLE_URL = `https://storage.googleapis.com/${ SAMPLE_PATH }`;
-  
+
         RisePlayerConfiguration = {
           isPreview: () => false
         };
@@ -64,22 +64,13 @@
       RisePlayerConfiguration.Logger = {};
     });
 
-    test( "should log 'configured' event with correct params", () => {
-      assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 0 ][ 0 ], componentData );
-      assert.equal( RisePlayerConfiguration.Logger.info.args[ 0 ][ 1 ], "configured");
-      assert.isNull( RisePlayerConfiguration.Logger.info.args[ 0 ][ 2 ] );
-      assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 0 ][ 3 ], {
-        storage: storageData
-      } );
-    });
-
     test( "should log 'start' event with correct params", () => {
       element.dispatchEvent( new CustomEvent( "start" ));
 
-      assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 1 ][ 0 ], componentData );
-      assert.equal( RisePlayerConfiguration.Logger.info.args[ 1 ][ 1 ], "start");
-      assert.isNull( RisePlayerConfiguration.Logger.info.args[ 1 ][ 2 ] );
-      assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 1 ][ 3 ], {
+      assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 0 ][ 0 ], componentData );
+      assert.equal( RisePlayerConfiguration.Logger.info.args[ 0 ][ 1 ], "start");
+      assert.isNull( RisePlayerConfiguration.Logger.info.args[ 0 ][ 2 ] );
+      assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 0 ][ 3 ], {
         storage: storageData
       } );
     });
@@ -91,10 +82,10 @@
       element.dispatchEvent( new CustomEvent( "start" ));
 
       setTimeout(() => {
-        assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 2 ][ 0 ], componentData );
-        assert.equal( RisePlayerConfiguration.Logger.info.args[ 2 ][ 1 ], "image-status-updated");
-        assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 2 ][ 2 ], { status: "CURRENT" });
-        assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 2 ][ 3 ], {
+        assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 1 ][ 0 ], componentData );
+        assert.equal( RisePlayerConfiguration.Logger.info.args[ 1 ][ 1 ], "image-status-updated");
+        assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 1 ][ 2 ], { status: "CURRENT" });
+        assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 1 ][ 3 ], {
           storage: storage
         } );
 
@@ -117,7 +108,7 @@
       element.dispatchEvent( new CustomEvent( "start" ));
 
       setTimeout( () => {
-        assert.equal( RisePlayerConfiguration.Logger.info.callCount, 2 ); // configure, start
+        assert.equal( RisePlayerConfiguration.Logger.info.callCount, 1 ); // start
 
         assert.deepEqual( RisePlayerConfiguration.Logger.error.args[ 0 ][ 0 ], componentData );
         assert.equal( RisePlayerConfiguration.Logger.error.args[ 0 ][ 1 ], "image-error");
@@ -125,7 +116,7 @@
           errorMessage: "image download error",
           errorDetail: "network failure"
         });
-        assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 1 ][ 3 ], {
+        assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 0 ][ 3 ], {
           storage: storageData
         } );
 


### PR DESCRIPTION
By deferring the isPreview call to a later step in the component's lifecycle, we can avoid this issue for rise-data-image.

I also removed the log call in ready() and from the tests that depended on that call.

I tested this manually on both electron and local chromeOS players.