### PR TITLE
Checking licensing authorization before watching file

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -9,7 +9,7 @@
       "resolved": "https://registry.npmjs.org/@polymer/polymer/-/polymer-3.0.5.tgz",
       "integrity": "sha512-Zbmhtr5vZ3NoHWwFYLKI4ff7yfE6DZopI8vaS7HvmUIuNqsv/EpEDXfNEYjqePQmkMX5LU9OIKV1eX/+9aveow==",
       "requires": {
-        "@webcomponents/shadycss": "1.5.2"
+        "@webcomponents/shadycss": "^1.2.0"
       }
     },
     "@polymer/sinonjs": {
@@ -76,7 +76,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -92,9 +92,9 @@
       "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
       "dev": true,
       "requires": {
-        "assertion-error": "1.1.0",
-        "deep-eql": "0.1.3",
-        "type-detect": "1.0.0"
+        "assertion-error": "^1.0.1",
+        "deep-eql": "^0.1.3",
+        "type-detect": "^1.0.0"
       }
     },
     "chalk": {
@@ -103,11 +103,11 @@
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "dev": true,
       "requires": {
-        "ansi-styles": "2.2.1",
-        "escape-string-regexp": "1.0.5",
-        "has-ansi": "2.0.0",
-        "strip-ansi": "3.0.1",
-        "supports-color": "2.0.0"
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
       },
       "dependencies": {
         "supports-color": {
@@ -124,7 +124,7 @@
       "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
       "dev": true,
       "requires": {
-        "graceful-readlink": "1.0.1"
+        "graceful-readlink": ">= 1.0.0"
       }
     },
     "concat-map": {
@@ -177,7 +177,7 @@
       "integrity": "sha1-XtPM1jZVEJc4NGXZlhmRAOhhYek=",
       "dev": true,
       "requires": {
-        "samsam": "1.1.2"
+        "samsam": "~1.1"
       }
     },
     "fs.realpath": {
@@ -192,12 +192,12 @@
       "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.2",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "graceful-readlink": {
@@ -218,7 +218,7 @@
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "has-flag": {
@@ -239,8 +239,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -267,8 +267,8 @@
       "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
       "dev": true,
       "requires": {
-        "lodash._basecopy": "3.0.1",
-        "lodash.keys": "3.1.2"
+        "lodash._basecopy": "^3.0.0",
+        "lodash.keys": "^3.0.0"
       }
     },
     "lodash._basecopy": {
@@ -301,9 +301,9 @@
       "integrity": "sha1-1/KEnw29p+BGgruM1yqwIkYd6+c=",
       "dev": true,
       "requires": {
-        "lodash._baseassign": "3.2.0",
-        "lodash._basecreate": "3.0.3",
-        "lodash._isiterateecall": "3.0.9"
+        "lodash._baseassign": "^3.0.0",
+        "lodash._basecreate": "^3.0.0",
+        "lodash._isiterateecall": "^3.0.0"
       }
     },
     "lodash.isarguments": {
@@ -324,9 +324,9 @@
       "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
       "dev": true,
       "requires": {
-        "lodash._getnative": "3.9.1",
-        "lodash.isarguments": "3.1.0",
-        "lodash.isarray": "3.0.4"
+        "lodash._getnative": "^3.0.0",
+        "lodash.isarguments": "^3.0.0",
+        "lodash.isarray": "^3.0.0"
       }
     },
     "lolex": {
@@ -341,7 +341,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -391,7 +391,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "path-is-absolute": {
@@ -415,7 +415,7 @@
         "formatio": "1.1.1",
         "lolex": "1.3.2",
         "samsam": "1.1.2",
-        "util": "0.11.0"
+        "util": ">=0.10.3 <1"
       }
     },
     "sinon-chai": {
@@ -430,8 +430,8 @@
       "integrity": "sha1-PxF+UYe5pz0j+HbWnwXIWxGAShI=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "lodash": "3.10.1"
+        "chalk": "^1.1.1",
+        "lodash": "^3.0.0"
       }
     },
     "strip-ansi": {
@@ -440,7 +440,7 @@
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "dev": true,
       "requires": {
-        "ansi-regex": "2.1.1"
+        "ansi-regex": "^2.0.0"
       }
     },
     "supports-color": {
@@ -449,7 +449,7 @@
       "integrity": "sha1-cqJiiU2dQIuVbKBf83su2KbiotU=",
       "dev": true,
       "requires": {
-        "has-flag": "1.0.0"
+        "has-flag": "^1.0.0"
       }
     },
     "type-detect": {
@@ -473,18 +473,18 @@
       "integrity": "sha512-23rbZwBh/DxWU36htJN9lsyBq3NxgVbuyMUq7fgFP6ZVTel+uFWO6LPXPoZQ6VyvXvlUYLE5PxY+ZdJ88a4COw==",
       "dev": true,
       "requires": {
-        "@polymer/polymer": "3.0.5",
-        "@polymer/sinonjs": "1.17.1",
-        "@polymer/test-fixture": "3.0.0-pre.21",
-        "@webcomponents/webcomponentsjs": "2.1.3",
-        "accessibility-developer-tools": "2.12.0",
-        "async": "1.5.2",
-        "chai": "3.5.0",
-        "lodash": "3.10.1",
-        "mocha": "3.5.3",
-        "sinon": "1.17.7",
-        "sinon-chai": "2.14.0",
-        "stacky": "1.3.1"
+        "@polymer/polymer": "^3.0.0",
+        "@polymer/sinonjs": "^1.14.1",
+        "@polymer/test-fixture": "^3.0.0-pre.1",
+        "@webcomponents/webcomponentsjs": "^2.0.0",
+        "accessibility-developer-tools": "^2.12.0",
+        "async": "^1.5.2",
+        "chai": "^3.5.0",
+        "lodash": "^3.10.1",
+        "mocha": "^3.4.2",
+        "sinon": "^1.17.1",
+        "sinon-chai": "^2.10.0",
+        "stacky": "^1.3.1"
       }
     },
     "wrappy": {

--- a/demo/src/rise-data-image-chromeos.html
+++ b/demo/src/rise-data-image-chromeos.html
@@ -57,6 +57,11 @@
             <p>image error: ${ event.detail.errorMessage }</p>
           `;
         });
+        image01.addEventListener('unlicensed', () => {
+          document.querySelector('#image01').innerHTML = `
+            <p>image warning: display is unlicensed</p>
+          `;
+        });
 
         // Start the component once it's configured;
         // but if it's already configured the listener won't work,

--- a/demo/src/rise-data-image-electron.html
+++ b/demo/src/rise-data-image-electron.html
@@ -57,6 +57,11 @@
             <p>image error: ${ event.detail.errorMessage }</p>
           `;
         });
+        image01.addEventListener('unlicensed', () => {
+          document.querySelector('#image01').innerHTML = `
+            <p>image warning: display is unlicensed</p>
+          `;
+        });
 
         // Start the component once it's configured;
         // but if it's already configured the listener won't work,

--- a/src/rise-data-image.js
+++ b/src/rise-data-image.js
@@ -50,6 +50,7 @@ class RiseDataImage extends PolymerElement {
     super();
 
     this.file = this.getAttribute( "file" );
+    this._watchInitiated = false;
   }
 
   ready() {
@@ -103,9 +104,12 @@ class RiseDataImage extends PolymerElement {
       if ( status.authorized ) {
         this._logInfo( RiseDataImage.EVENT_LICENSED );
 
-        RisePlayerConfiguration.LocalStorage.watchSingleFile(
-          this.file, message => this._handleSingleFileUpdate( message )
-        );
+        if ( !this._watchInitiated ) {
+          RisePlayerConfiguration.LocalStorage.watchSingleFile(
+            this.file, message => this._handleSingleFileUpdate( message )
+          );
+          this._watchInitiated = true;
+        }
       } else {
         this._logWarning( RiseDataImage.EVENT_UNLICENSED );
         this._sendImageEvent( RiseDataImage.EVENT_UNLICENSED );

--- a/test/integration/rise-data-image-logging.html
+++ b/test/integration/rise-data-image-logging.html
@@ -26,6 +26,8 @@
 </test-fixture>
 
 <script>
+  let licenseMock = { authorized: true };
+
   suite( "logging", () => {
     const componentData = {
         name: "rise-data-image",
@@ -53,7 +55,12 @@
 
       RisePlayerConfiguration.Logger = {
         info: sinon.spy(),
-        error: sinon.spy()
+        error: sinon.spy(),
+        warning: sinon.spy()
+      };
+
+      RisePlayerConfiguration.Licensing = {
+        onStorageLicenseStatusChange: handler => handler( licenseMock )
       };
 
       element = fixture( "test-block" );
@@ -62,6 +69,7 @@
     teardown(() => {
       RisePlayerConfiguration.LocalStorage = {};
       RisePlayerConfiguration.Logger = {};
+      RisePlayerConfiguration.Licensing = {};
     });
 
     test( "should log 'start' event with correct params", () => {
@@ -83,11 +91,31 @@
 
       setTimeout(() => {
         assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 1 ][ 0 ], componentData );
-        assert.equal( RisePlayerConfiguration.Logger.info.args[ 1 ][ 1 ], "image-status-updated");
-        assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 1 ][ 2 ], { status: "CURRENT" });
-        assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 1 ][ 3 ], {
+        assert.equal( RisePlayerConfiguration.Logger.info.args[ 1 ][ 1 ], "licensed");
+
+        assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 2 ][ 0 ], componentData );
+        assert.equal( RisePlayerConfiguration.Logger.info.args[ 2 ][ 1 ], "image-status-updated");
+        assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 2 ][ 2 ], { status: "CURRENT" });
+        assert.deepEqual( RisePlayerConfiguration.Logger.info.args[ 2 ][ 3 ], {
           storage: storage
         } );
+
+        done();
+      }, watchTimeoutDuration );
+    });
+
+    test( "should log 'unlicensed' warning event", done => {
+      const storage = Object.assign({}, storageData);
+      storage.local_url = SAMPLE_URL;
+      licenseMock = {authorized: false};
+
+      element.dispatchEvent( new CustomEvent( "start" ));
+
+      setTimeout(() => {
+        assert.deepEqual( RisePlayerConfiguration.Logger.warning.args[ 0 ][ 0 ], componentData );
+        assert.equal( RisePlayerConfiguration.Logger.warning.args[ 0 ][ 1 ], "unlicensed");
+
+        licenseMock = {authorized: true};
 
         done();
       }, watchTimeoutDuration );
@@ -108,7 +136,7 @@
       element.dispatchEvent( new CustomEvent( "start" ));
 
       setTimeout( () => {
-        assert.equal( RisePlayerConfiguration.Logger.info.callCount, 1 ); // start
+        assert.equal( RisePlayerConfiguration.Logger.info.callCount, 2 ); // start, licensing
 
         assert.deepEqual( RisePlayerConfiguration.Logger.error.args[ 0 ][ 0 ], componentData );
         assert.equal( RisePlayerConfiguration.Logger.error.args[ 0 ][ 1 ], "image-error");

--- a/test/unit/rise-data-image.html
+++ b/test/unit/rise-data-image.html
@@ -26,6 +26,8 @@
     </test-fixture>
 
     <script>
+      let licenseMock = { authorized: true };
+
       suite('rise-data-image', () => {
         let element;
 
@@ -40,7 +42,12 @@
 
           RisePlayerConfiguration.Logger = {
             info: () => {},
-            error: () => {}
+            error: () => {},
+            warning: () => {}
+          };
+
+          RisePlayerConfiguration.Licensing = {
+            onStorageLicenseStatusChange: handler => handler( licenseMock )
           };
 
           element = fixture('test-block');
@@ -49,6 +56,7 @@
         teardown(() => {
           RisePlayerConfiguration.LocalStorage = {};
           RisePlayerConfiguration.Logger = {};
+          RisePlayerConfiguration.Licensing = {};
         });
 
         test('it should have a property file', () => {
@@ -65,6 +73,22 @@
 
             done();
           });
+
+          element.addEventListener('configured', () =>
+            element.dispatchEvent( new CustomEvent( "start" ) )
+          );
+          element.dispatchEvent( new CustomEvent( "start" ) );
+        });
+
+        test("is should send an 'unlicensed' event if display is unlicensed", done => {
+          element.addEventListener('unlicensed', event => {
+            assert.deepEqual(event.detail, {});
+            licenseMock = {authorized: true};
+
+            done();
+          });
+
+          licenseMock = {authorized: false};
 
           element.addEventListener('configured', () =>
             element.dispatchEvent( new CustomEvent( "start" ) )
@@ -90,12 +114,17 @@
                   error: () => {}
               };
 
+              RisePlayerConfiguration.Licensing = {
+                onStorageLicenseStatusChange: handler => handler( licenseMock )
+              };
+
               element = fixture('test-block');
           });
 
           teardown(() => {
               RisePlayerConfiguration.LocalStorage = {};
               RisePlayerConfiguration.Logger = {};
+              RisePlayerConfiguration.Licensing = {};
           });
 
           test('it should send an image updated event with NOEXIST status if an image does not exist', done => {
@@ -138,12 +167,17 @@
                   error: () => {}
               };
 
+              RisePlayerConfiguration.Licensing = {
+                onStorageLicenseStatusChange: handler => handler( licenseMock )
+              };
+
               element = fixture('test-block');
           });
 
           teardown(() => {
               RisePlayerConfiguration.LocalStorage = {};
               RisePlayerConfiguration.Logger = {};
+              RisePlayerConfiguration.Licensing = {};
           });
 
           test('it should send an image error event if an image local storage error was received', done => {


### PR DESCRIPTION
- Using latest common-template Licensing to check for authorization
  - Logging `licensed` info event to BQ when authorization received
  - Starting watch of file upon authorization confirmation
  - Logging `unlicensed` warning event and sending `unlicensed` component event when authorization is received and it's `false` 